### PR TITLE
fix(doubao): refresh UI capability detection

### DIFF
--- a/docs/handoffs/2026-07-31-doubao-ui-capability-refresh-01.md
+++ b/docs/handoffs/2026-07-31-doubao-ui-capability-refresh-01.md
@@ -1,0 +1,85 @@
+# DOUBAO-UI-CAPABILITY-REFRESH-01 交接报告
+
+## 治理与冻结范围
+
+已完整读取中央记忆入口、开发效率治理、中央 CURRENT/DEPENDENCIES/QUEUE/ROADMAP、项目 AGENTS.md、README、ROADMAP、DESIGN、AGENT_EXECUTION_PLAN、GLM_NEXT_TASK 和相关源码/测试。
+
+本包只有一个核心目标和三个 P0：新 UI 只读能力快照、Provider Adapter/选择器适配、会员门槛 fail-closed。没有 P1。未扩展到 Core/CLI/G-302、Alice Agent 或真实生成。
+
+## 基线
+
+- 仓库：`D:\豆包工作室\doubao-studio-main`
+- 分支：`glm/g-405-persistence-normalization`
+- HEAD：`850bfbf030a3e8ffa8a8a6927d9ffe6fb2be199e`（本任务未提交）
+- 现存 `AGENTS.md` 修改保持不变，未覆盖、恢复或暂存。
+
+## P0 结果
+
+### P0-1 新 UI 只读能力快照
+
+- 新增纯函数能力观察器，记录 `observed_at`、账户层级、页面 URL、适配器版本和 observed/partial/unknown 状态。
+- 只读识别新主入口、Seedance/Seedream 模型、4–15 秒、视频/图片比例和会员动作文字。
+- 缺失或歧义返回 unknown，不猜价格、倍率、免费权益或账户资格。
+- Adapter self-check 将机器可读快照写入报告项；整个过程只读取 DOM，不点击生成、购买或升级。
+
+### P0-2 Adapter 与配置适配
+
+- Adapter 版本升至 `2.0.0-20260731`，更新时长、新入口和会员弹窗识别。
+- 增加 Seedance 2.5，视频时长类型、IPC CSV 校验、持久化归一化和 UI 选择范围统一为 4–15 秒。
+- 默认时长由 15 秒改为 10 秒。模型倍率只显示“页面实时显示”，不固化截图倍率。
+- 视频 DOM 配置仅选择页面可见选项；dry-run 结果固定 `finalSubmit=false`。
+
+### P0-3 会员门槛 fail-closed
+
+- 11–15 秒只有页面实时明确 `selectable` 才可继续；出现会员动作或缺少证据均阻断。
+- BrowserPanel 已删除手动 15 秒开关、页面加载注入和自动任务请求改写调用。
+- 历史导出入口固定返回 false，不访问 Webview；行为测试证明不能重新启用。
+- 阻断发生在提示词提交、额度扣减和产物轮询前。
+
+## 实际业务/测试修改文件（12 个）
+
+1. `src/automation/doubaoCapability.ts`（新增）
+2. `src/automation/doubaoAdapter.ts`
+3. `src/utils/videoCapability.ts`
+4. `src/utils/doubaoBridge.ts`
+5. `src/components/BrowserPanel.tsx`
+6. `src/components/TaskConsole.tsx`
+7. `src/types/index.ts`
+8. `packages/contracts/src/enums.ts`
+9. `main/ipc/tasks.ts`
+10. `main/utils/persistenceNormalization.ts`
+11. `tests/unit/videoCapability.test.ts`
+12. 本 handoff
+
+中央安排阶段已经存在的 `GLM_NEXT_TASK.md`、`ROADMAP.md`、优先级 handoff 和受保护 `AGENTS.md` 不属于本功能包改动。
+
+## 验证
+
+- 新增专项测试：8 项（总文件 46/46 pass）。
+- 相关回归：6 文件，224/224 pass。
+- `pnpm.cmd run ts-check`：通过。
+- 全局 Lint：0 error，145 warning，低于仓库冻结上限 149。
+- `pnpm.cmd run validate`：退出码 0；15 文件、487 测试全部通过；工程结构、contracts 边界和生产构建通过。
+- `git diff --check`：无本任务空白错误，仅 Git 的 CRLF 转换警告。
+
+## 能力证据边界
+
+用户截图于 2026-07-31 观察到当前账户视频 4–15 秒、11–15 秒出现会员购买窗口、新模型/比例/入口。该事实只作为带时间与账户上下文的适配输入，不是平台永久规则。本任务没有登录或控制真实豆包页面，因此没有伪造“真实页面已人工冒烟通过”。
+
+## 安全声明与状态
+
+- 未真实生成视频或图片，未消耗额度。
+- 未购买会员，未点击支付/升级，未绕过会员限制。
+- 未读取或输出 Cookie、Token、签名、`.env`、支付信息或账号隐私。
+- 未修改 Alice Agent、ERP、Discord Workspace 或 PR #21 工作副本。
+- 已实现：是；已测试：是；已提交：否；已推送：否；已部署：否；已发布：否。
+
+## 分流事项
+
+- 历史请求改写实现的物理删除可作为后续独立清理包；当前生产调用面和启用入口已移除并固定拒绝。
+- 真实页面手工 dry-run/selector 冒烟需用户后续单独授权并在不点击最终生成的前提下执行。
+- Seedream 具体生成参数写入、风格/模板自动选择和倍率展示属于 NEXT，不进入本冻结包。
+
+## R1 最小整改
+
+总架构师复核发现 dry-run 在 11–15 秒且会员可用性为 unknown 时仍可能返回 ready。R1 只修改原 P0-3 的纯函数与既有测试：11–15 秒现在只有显式 `selectable` 才返回 ready，`unknown` 和 `action_required` 均返回 `membership_required`。参数化测试覆盖 unknown/selectable；相关回归 224/224、TypeScript、任务文件 Lint 和 diff-check 全部通过。未增加文件或功能范围。完整 validate 的 487 项结果产生于 R1 前；按治理规则本次最小整改未重复运行候选级全量门禁。

--- a/main/ipc/accounts.ts
+++ b/main/ipc/accounts.ts
@@ -6,6 +6,7 @@
 
 import { ipcMain, session } from 'electron';
 import { readJSON, writeJSON } from '../utils/store';
+import { normalizeAccounts } from '../utils/persistenceNormalization';
 import { v4 as uuidv4 } from 'uuid';
 import type {
   Account,
@@ -82,9 +83,18 @@ function normalizeScheduling(account: Account): void {
   }
 }
 
-/** 读取所有账号 */
+/** 读取所有账号（含运行时归一化） */
 function loadAccounts(): Account[] {
-  return readJSON<Account[]>(STORE_FILE, []);
+  const raw = readJSON<unknown>(STORE_FILE, []);
+  const result = normalizeAccounts(raw);
+  // 仅在归一化确实改变数据时写回磁盘，避免每次读取产生无意义磁盘 IO
+  if (result.changed) {
+    saveAccounts(result.data);
+  }
+  if (result.warnings.length > 0) {
+    console.warn('[Accounts] 数据归一化告警:', result.warnings);
+  }
+  return result.data;
 }
 
 /** 保存所有账号 */
@@ -133,17 +143,8 @@ async function clearAccountSession(partition: string): Promise<void> {
 export function registerAccountIPC(): void {
   // ---- 获取所有账号 ----
   ipcMain.handle('accounts:list', async (): Promise<Account[]> => {
-    const accounts = loadAccounts();
-    // 规范化前快照，用于判断是否真正产生了字段补全或额度重置
-    const before = JSON.stringify(accounts);
-    accounts.forEach(normalizeQuota);
-    accounts.forEach(normalizeHealth);
-    accounts.forEach(normalizeScheduling);
-    // 仅在规范化确实改变了数据时写盘，避免每次 list 都产生无意义磁盘 IO
-    if (JSON.stringify(accounts) !== before) {
-      saveAccounts(accounts);
-    }
-    return accounts;
+    // loadAccounts 已内置运行时归一化（额度日期重置、健康/调度补全、重复 ID 去重）
+    return loadAccounts();
   });
 
   // ---- 添加账号 ----

--- a/main/ipc/tasks.ts
+++ b/main/ipc/tasks.ts
@@ -6,6 +6,7 @@
 
 import { ipcMain, dialog, session } from 'electron';
 import { readJSON, writeJSON } from '../utils/store';
+import { normalizeTasks, normalizeDownloadJobs } from '../utils/persistenceNormalization';
 import { validateDownloadResponse, classifyDownloadException } from '../utils/downloadValidation';
 import { v4 as uuidv4 } from 'uuid';
 import { getDefaultProjectId } from './projects';
@@ -58,25 +59,19 @@ const STORE_FILE = 'tasks.json';
 const DOWNLOAD_STORE_FILE = 'downloads.json';
 let downloadRecoveryApplied = false;
 
+/** 读取所有任务（含运行时归一化） */
 function loadTasks(): Task[] {
   const defaultProjectId = getDefaultProjectId();
-  const rawTasks = readJSON<Task[]>(STORE_FILE, []);
-  let migrated = false;
-  const tasks = rawTasks.map((task) => {
-    if (!task.projectId) migrated = true;
-    return ({
-    ...task,
-    mode: task.mode || 'chat',
-    outputs: Array.isArray(task.outputs) ? task.outputs : [],
-    artifacts: Array.isArray(task.artifacts) ? task.artifacts : [],
-    runHistory: Array.isArray(task.runHistory) ? task.runHistory : [],
-    source: task.source || 'manual',
-    dependsOnTaskIds: Array.isArray(task.dependsOnTaskIds) ? task.dependsOnTaskIds : [],
-    projectId: task.projectId || defaultProjectId,
-  });
-  });
-  if (migrated) writeJSON(STORE_FILE, tasks);
-  return tasks;
+  const raw = readJSON<unknown>(STORE_FILE, []);
+  const result = normalizeTasks(raw, defaultProjectId);
+  // 仅在归一化确实改变数据时写回磁盘
+  if (result.changed) {
+    writeJSON(STORE_FILE, result.data);
+  }
+  if (result.warnings.length > 0) {
+    console.warn('[Tasks] 数据归一化告警:', result.warnings);
+  }
+  return result.data;
 }
 
 function artifactId(url: string): string {
@@ -115,8 +110,19 @@ function saveTasksOrError(tasks: Task[]): { success: true } | { success: false; 
     : { success: false, error: '任务数据写入失败，请检查磁盘空间和数据目录权限' };
 }
 
+/** 读取下载记录（含运行时归一化 + 中断恢复） */
 function loadDownloadJobs(): DownloadJob[] {
-  const jobs = readJSON<DownloadJob[]>(DOWNLOAD_STORE_FILE, []);
+  const raw = readJSON<unknown>(DOWNLOAD_STORE_FILE, []);
+  const result = normalizeDownloadJobs(raw);
+  // 仅在归一化确实改变数据时写回磁盘
+  if (result.changed) {
+    writeJSON(DOWNLOAD_STORE_FILE, result.data);
+  }
+  if (result.warnings.length > 0) {
+    console.warn('[Downloads] 数据归一化告警:', result.warnings);
+  }
+  const jobs = result.data;
+  // 下载中断恢复：将上次进程遗留的 'downloading' 状态标记为 'failed'
   if (!downloadRecoveryApplied) {
     downloadRecoveryApplied = true;
     let changed = false;

--- a/main/ipc/tasks.ts
+++ b/main/ipc/tasks.ts
@@ -545,8 +545,8 @@ export function registerTaskIPC(): void {
           imported.push({
             id: uuidv4(), prompt, assignedAccountId: account?.id || null, status: 'queued', mode,
             videoConfig: mode === 'video' ? {
-              model: ['seedance-2.0', 'seedance-2.0-fast', 'seedance-2.0-mini'].includes(model) ? model : 'seedance-2.0',
-              duration: ['5s', '10s', '15s'].includes(duration) ? duration : '10s',
+              model: ['seedance-2.5', 'seedance-2.0', 'seedance-2.0-fast', 'seedance-2.0-mini'].includes(model) ? model : 'seedance-2.0',
+              duration: /^(?:[4-9]|1[0-5])s$/.test(duration) ? duration : '10s',
               aspectRatio: ['1:1', '3:4', '4:3', '9:16', '16:9', '21:9'].includes(aspectRatio) ? aspectRatio : '16:9',
             } : undefined,
             attachments: attachmentsIndex >= 0 ? (row[attachmentsIndex] || '').split('|').map((item) => item.trim()).filter(Boolean) : undefined,

--- a/main/utils/persistenceNormalization.ts
+++ b/main/utils/persistenceNormalization.ts
@@ -67,8 +67,8 @@ const VALID_ARTIFACT_SOURCES = ['network', 'page', 'manual'] as const;
 const VALID_LOGIN_STATES = ['unknown', 'ok', 'expired'] as const;
 const VALID_RUN_OUTCOMES = ['done', 'failed', 'paused', 'cancelled'] as const;
 const VALID_TASK_SOURCES = ['manual', 'csv', 'workflow'] as const;
-const VALID_VIDEO_MODELS = ['seedance-2.0', 'seedance-2.0-fast', 'seedance-2.0-mini'] as const;
-const VALID_VIDEO_DURATIONS = ['5s', '10s', '15s'] as const;
+const VALID_VIDEO_MODELS = ['seedance-2.5', 'seedance-2.0', 'seedance-2.0-fast', 'seedance-2.0-mini'] as const;
+const VALID_VIDEO_DURATIONS = ['4s', '5s', '6s', '7s', '8s', '9s', '10s', '11s', '12s', '13s', '14s', '15s'] as const;
 const VALID_VIDEO_ASPECT_RATIOS = ['1:1', '3:4', '4:3', '9:16', '16:9', '21:9'] as const;
 const VALID_VALIDATION_STATES = ['unknown', 'valid', 'expired', 'invalid'] as const;
 

--- a/main/utils/persistenceNormalization.ts
+++ b/main/utils/persistenceNormalization.ts
@@ -1,0 +1,696 @@
+/**
+ * main/utils/persistenceNormalization.ts
+ *
+ * 本地持久化数据运行时归一化层。
+ *
+ * 为 accounts.json / tasks.json / downloads.json 提供轻量级运行时校验与归一化，
+ * 解决历史数据、手工修改、版本迁移或字段异常导致的调度和 UI 不稳定问题。
+ *
+ * 设计原则：
+ * - 读取后安全可用、保留可恢复信息、绝不静默丢弃用户任务。
+ * - 纯函数：不修改输入，不产生副作用，可独立测试。
+ * - 仅在归一化确实改变数据时标记 changed=true，由调用方决定是否写回磁盘。
+ * - 顶层结构错误时返回空数组且 changed=false，绝不覆盖原文件。
+ *
+ * 不引入 AJV、Zod 等新依赖；不修改 IPC channel 名称、preload API 或磁盘文件名。
+ */
+
+import type {
+  Account,
+  Task,
+  DownloadJob,
+  SeedanceQuota,
+  AccountHealth,
+  AccountScheduling,
+  TaskArtifact,
+  TaskErrorInfo,
+  TaskRunSnapshot,
+  TaskRunRecord,
+  TaskLock,
+  GenerationMode,
+  AccountStatus,
+  TaskStatus,
+  TaskStage,
+  DependencyPolicy,
+} from '@doubao-studio/contracts';
+
+// ==================== 公共类型 ====================
+
+/** 归一化结果 */
+export interface NormalizeResult<T> {
+  /** 归一化后的数据数组 */
+  data: T[];
+  /** 归一化是否改变了数据（调用方据此决定是否写回磁盘） */
+  changed: boolean;
+  /** 诊断告警：被跳过、恢复或修正的项的可读原因 */
+  warnings: string[];
+}
+
+// ==================== 合法值集合 ====================
+
+const VALID_GENERATION_MODES: readonly GenerationMode[] = ['chat', 'image', 'video', 'music'];
+const VALID_ACCOUNT_STATUSES: readonly AccountStatus[] = ['idle', 'busy', 'error'];
+const VALID_TASK_STATUSES: readonly TaskStatus[] = [
+  'queued', 'executing', 'generating', 'waiting_verification',
+  'paused', 'done', 'fail', 'cancelled',
+];
+const VALID_TASK_STAGES: readonly TaskStage[] = [
+  'queued', 'preparing_account', 'new_conversation', 'switching_mode',
+  'configuring', 'uploading_assets', 'injecting_prompt', 'submitting',
+  'waiting_verification', 'generating', 'extracting_outputs',
+  'completed', 'paused', 'failed', 'cancelled',
+];
+const VALID_DEPENDENCY_POLICIES: readonly DependencyPolicy[] = ['all_done', 'all_finished'];
+const VALID_DOWNLOAD_STATUSES = ['queued', 'downloading', 'done', 'failed'] as const;
+const VALID_ARTIFACT_KINDS = ['image', 'video', 'file'] as const;
+const VALID_ARTIFACT_SOURCES = ['network', 'page', 'manual'] as const;
+const VALID_LOGIN_STATES = ['unknown', 'ok', 'expired'] as const;
+const VALID_RUN_OUTCOMES = ['done', 'failed', 'paused', 'cancelled'] as const;
+const VALID_TASK_SOURCES = ['manual', 'csv', 'workflow'] as const;
+const VALID_VIDEO_MODELS = ['seedance-2.0', 'seedance-2.0-fast', 'seedance-2.0-mini'] as const;
+const VALID_VIDEO_DURATIONS = ['5s', '10s', '15s'] as const;
+const VALID_VIDEO_ASPECT_RATIOS = ['1:1', '3:4', '4:3', '9:16', '16:9', '21:9'] as const;
+const VALID_VALIDATION_STATES = ['unknown', 'valid', 'expired', 'invalid'] as const;
+
+const DEFAULT_SEEDANCE_DAILY_UNITS = 10;
+
+// ==================== 基础类型辅助函数 ====================
+
+/** 判断值是否为普通对象（非 null、非数组） */
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** 安全取字符串，非法值回退 */
+function asString(value: unknown, fallback: string): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+/** 安全取非空字符串 */
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/** 安全取布尔值 */
+function asBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+/** 安全取有限数字 */
+function asNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+/** 安全取非负有限数字 */
+function asNonNegativeNumber(value: unknown, fallback: number): number {
+  const n = asNumber(value, fallback);
+  return n >= 0 ? n : fallback;
+}
+
+/** 判断字符串是否为有效 ISO 日期 */
+function isValidISODate(value: unknown): value is string {
+  if (typeof value !== 'string' || value.length === 0) return false;
+  const d = new Date(value);
+  return !isNaN(d.getTime());
+}
+
+/** 安全取 ISO 日期字符串，非法值回退 */
+function asISODate(value: unknown, fallback: string): string {
+  return isValidISODate(value) ? value : fallback;
+}
+
+/** 判断值是否属于合法值集合，不属于时返回 fallback */
+function oneOf<T extends string>(value: unknown, valid: readonly T[], fallback: T): T {
+  return typeof value === 'string' && (valid as readonly string[]).includes(value)
+    ? (value as T)
+    : fallback;
+}
+
+/** 判断值是否属于合法值集合，不属于时返回 undefined */
+function optionalOneOf<T extends string>(value: unknown, valid: readonly T[]): T | undefined {
+  return typeof value === 'string' && (valid as readonly string[]).includes(value)
+    ? (value as T)
+    : undefined;
+}
+
+/** 安全取字符串数组（过滤非字符串项） */
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
+}
+
+/**
+ * 计算本地日期键（YYYY-MM-DD），与 accounts.ts 中 localDateKey 语义一致。
+ */
+function localDateKeyFromISO(isoNow: string): string {
+  const now = new Date(isoNow);
+  const offset = now.getTimezoneOffset() * 60000;
+  return new Date(now.getTime() - offset).toISOString().slice(0, 10);
+}
+
+// ==================== 账号归一化 ====================
+
+/**
+ * 归一化账号的 Seedance 额度记录。
+ * - 缺失或日期非今日时重置 usedUnits。
+ * - 负数 usedUnits / estimatedTotalUnits 安全回退为 0 / 默认值。
+ * 直接修改传入的 account 对象（内部使用，由 normalizeAccounts 在深拷贝上调用）。
+ */
+export function normalizeAccountQuota(account: Account, now: string): void {
+  const today = localDateKeyFromISO(now);
+  const quota = account.seedanceQuota;
+
+  if (!isObject(quota) || !isValidISODate(quota.date) || quota.date !== today) {
+    account.seedanceQuota = {
+      date: today,
+      usedUnits: 0,
+      estimatedTotalUnits: isObject(quota) && typeof quota.estimatedTotalUnits === 'number' && quota.estimatedTotalUnits > 0
+        ? quota.estimatedTotalUnits
+        : DEFAULT_SEEDANCE_DAILY_UNITS,
+      exhausted: false,
+      updatedAt: now,
+    };
+    return;
+  }
+
+  // quota 存在且日期为今日 — 修正非法数值
+  const fixed: SeedanceQuota = {
+    date: today,
+    usedUnits: asNonNegativeNumber(quota.usedUnits, 0),
+    estimatedTotalUnits: asNonNegativeNumber(quota.estimatedTotalUnits, DEFAULT_SEEDANCE_DAILY_UNITS),
+    exhausted: asBoolean(quota.exhausted, false),
+    updatedAt: asISODate(quota.updatedAt, now),
+  };
+  account.seedanceQuota = fixed;
+}
+
+/**
+ * 归一化账号健康状态。
+ * - 补全缺失字段为安全默认值。
+ * - lastErrorCode 保持为 string，不收紧为联合类型。
+ * - 已过期的 cooldownUntil / manualCooldownUntil 清除。
+ */
+export function normalizeAccountHealth(account: Account, now: string): void {
+  const raw = account.health;
+  const nowMs = new Date(now).getTime();
+  const lastSuccessAt = raw?.lastSuccessAt;
+  const lastFailureAt = raw?.lastFailureAt;
+  const cooldownUntil = raw?.cooldownUntil;
+
+  const health: AccountHealth = {
+    loginState: oneOf(raw?.loginState, VALID_LOGIN_STATES, 'unknown') as AccountHealth['loginState'],
+    verificationRequired: asBoolean(raw?.verificationRequired, false),
+    consecutiveFailures: asNonNegativeNumber(raw?.consecutiveFailures, 0),
+    successCount: asNonNegativeNumber(raw?.successCount, 0),
+    failureCount: asNonNegativeNumber(raw?.failureCount, 0),
+    lastSuccessAt: isValidISODate(lastSuccessAt) ? lastSuccessAt : undefined,
+    lastFailureAt: isValidISODate(lastFailureAt) ? lastFailureAt : undefined,
+    // lastErrorCode 保持 string，不校验为 TaskErrorCode 联合
+    lastErrorCode: typeof raw?.lastErrorCode === 'string' ? raw.lastErrorCode : undefined,
+    cooldownUntil: isValidISODate(cooldownUntil) ? cooldownUntil : undefined,
+  };
+
+  // 已过期的 cooldown 清除
+  if (health.cooldownUntil && new Date(health.cooldownUntil).getTime() <= nowMs) {
+    health.cooldownUntil = undefined;
+    health.verificationRequired = false;
+  }
+
+  account.health = health;
+}
+
+/**
+ * 归一化账号调度配置。
+ * - 补全缺失字段为安全默认值。
+ * - weight 裁剪到 [0.1, 10]。
+ * - 已过期的 manualCooldownUntil 清除。
+ */
+export function normalizeAccountScheduling(account: Account, now: string): void {
+  const raw = account.scheduling;
+  const nowMs = new Date(now).getTime();
+
+  const manualCooldownUntil = raw?.manualCooldownUntil;
+  const scheduling: AccountScheduling = {
+    enabled: asBoolean(raw?.enabled, true),
+    weight: Math.max(0.1, Math.min(10, asNumber(raw?.weight, 1))),
+    preferredModes: asStringArray(raw?.preferredModes).filter(
+      (m): m is GenerationMode => (VALID_GENERATION_MODES as readonly string[]).includes(m),
+    ),
+    manualCooldownUntil: isValidISODate(manualCooldownUntil) ? manualCooldownUntil : undefined,
+  };
+
+  if (scheduling.manualCooldownUntil && new Date(scheduling.manualCooldownUntil).getTime() <= nowMs) {
+    scheduling.manualCooldownUntil = undefined;
+  }
+
+  account.scheduling = scheduling;
+}
+
+/**
+ * 在深拷贝的对象上执行账号字段归一化（直接修改传入对象）。
+ * 输入必须是 isObject 通过的对象。
+ */
+function normalizeAccountObject(raw: Record<string, unknown>, now: string): Account {
+  const account = raw as unknown as Account;
+
+  // 基础字段
+  account.id = asNonEmptyString(raw.id) ?? `recovered-${now}-${Math.random().toString(36).slice(2, 10)}`;
+  account.name = asString(raw.name, '');
+  account.avatar = asString(raw.avatar, '');
+  account.partition = asNonEmptyString(raw.partition) ?? `account_${account.id.slice(0, 8)}`;
+  account.status = oneOf(raw.status, VALID_ACCOUNT_STATUSES, 'idle');
+  account.pinned = asBoolean(raw.pinned, false);
+  account.createdAt = asISODate(raw.createdAt, now);
+  account.updatedAt = asISODate(raw.updatedAt, now);
+
+  // 嵌套结构
+  normalizeAccountQuota(account, now);
+  normalizeAccountHealth(account, now);
+  normalizeAccountScheduling(account, now);
+
+  return account;
+}
+
+/**
+ * 归一化 accounts.json 原始数据。
+ *
+ * @param raw - readJSON 返回的原始数据
+ * @param now - 当前 ISO 时间字符串（默认 new Date().toISOString()）
+ * @returns 归一化结果
+ */
+export function normalizeAccounts(
+  raw: unknown,
+  now: string = new Date().toISOString(),
+): NormalizeResult<Account> {
+  // 顶层不是数组 — 安全回退为空数组，不覆盖原文件
+  if (!Array.isArray(raw)) {
+    return {
+      data: [],
+      changed: false,
+      warnings: ['accounts.json 顶层结构不是数组，已安全回退为空数组（不覆盖原文件）'],
+    };
+  }
+
+  // 深拷贝以避免修改输入
+  const cloned: unknown[] = JSON.parse(JSON.stringify(raw));
+  const originalJson = JSON.stringify(raw);
+  const warnings: string[] = [];
+  const seenIds = new Set<string>();
+  const result: Account[] = [];
+  let skippedCount = 0;
+
+  for (let i = 0; i < cloned.length; i++) {
+    const item = cloned[i];
+    if (!isObject(item)) {
+      skippedCount++;
+      warnings.push(`账号数组索引 ${i} 不是对象，已跳过`);
+      continue;
+    }
+    const account = normalizeAccountObject(item, now);
+    if (!account.id || seenIds.has(account.id)) {
+      skippedCount++;
+      warnings.push(`跳过重复或无效 ID 的账号 (索引 ${i})`);
+      continue;
+    }
+    seenIds.add(account.id);
+    result.push(account);
+  }
+
+  if (skippedCount > 0 && warnings.length > 0) {
+    // warnings 已包含逐项原因，此处不再重复汇总
+  }
+
+  const changed = JSON.stringify(result) !== originalJson;
+  return { data: result, changed, warnings };
+}
+
+// ==================== 任务归一化 ====================
+
+/**
+ * 归一化任务产物（TaskArtifact）。
+ * 缺少 id 或 url 的产物会被丢弃。
+ */
+function normalizeArtifacts(raw: unknown, taskMode: GenerationMode, now: string): { artifacts: TaskArtifact[]; changed: boolean } {
+  if (!Array.isArray(raw)) return { artifacts: [], changed: true };
+
+  const result: TaskArtifact[] = [];
+  let changed = false;
+  const seenUrls = new Set<string>();
+
+  for (const item of raw) {
+    if (!isObject(item)) {
+      changed = true;
+      continue;
+    }
+    const url = asNonEmptyString(item.url);
+    const id = asNonEmptyString(item.id);
+    if (!url || !id) {
+      changed = true;
+      continue;
+    }
+    if (seenUrls.has(url)) {
+      changed = true;
+      continue;
+    }
+    seenUrls.add(url);
+
+    const artifact: TaskArtifact = {
+      id,
+      url,
+      kind: oneOf(item.kind, VALID_ARTIFACT_KINDS, taskMode === 'video' ? 'video' : taskMode === 'image' ? 'image' : 'file') as TaskArtifact['kind'],
+      source: oneOf(item.source, VALID_ARTIFACT_SOURCES, 'network') as TaskArtifact['source'],
+      runId: asNonEmptyString(item.runId) ?? undefined,
+      conversationUrl: asNonEmptyString(item.conversationUrl) ?? undefined,
+      discoveredAt: asISODate(item.discoveredAt, now),
+    };
+
+    // validation 子对象
+    if (isObject(item.validation)) {
+      const v: Record<string, unknown> = item.validation;
+      artifact.validation = {
+        state: oneOf(v.state, VALID_VALIDATION_STATES, 'unknown') as NonNullable<TaskArtifact['validation']>['state'],
+        checkedAt: asISODate(v.checkedAt, now),
+        contentType: asNonEmptyString(v.contentType) ?? undefined,
+        contentLength: typeof v.contentLength === 'number' && v.contentLength >= 0 ? v.contentLength : undefined,
+        statusCode: typeof v.statusCode === 'number' ? v.statusCode : undefined,
+        error: asNonEmptyString(v.error) ?? undefined,
+      };
+    }
+
+    result.push(artifact);
+
+    // 检测是否与原始数据不同
+    if (JSON.stringify(artifact) !== JSON.stringify(item)) {
+      changed = true;
+    }
+  }
+
+  if (result.length !== raw.length) changed = true;
+  return { artifacts: result, changed };
+}
+
+/**
+ * 归一化 TaskErrorInfo。
+ * code 保持 string，不收紧为联合类型；未知 code 保留不抛错。
+ */
+function normalizeErrorInfo(raw: unknown, now: string): TaskErrorInfo | undefined {
+  if (!isObject(raw)) return undefined;
+  const code = asString(raw.code, 'unknown');
+  return {
+    code, // 保留原始 string，包括未知错误码
+    message: asString(raw.message, ''),
+    recoverable: asBoolean(raw.recoverable, true),
+    detectedAt: asISODate(raw.detectedAt, now),
+  };
+}
+
+/**
+ * 归一化 TaskRunSnapshot（运行快照）。
+ */
+function normalizeRuntime(raw: unknown, taskMode: GenerationMode, now: string): TaskRunSnapshot | undefined {
+  if (!isObject(raw)) return undefined;
+  const r = raw;
+  const input = r.input;
+  const videoConfig = r.videoConfig ?? (isObject(input) ? input.videoConfig : undefined);
+
+  return {
+    runId: asString(r.runId, ''),
+    attempt: asNonNegativeNumber(r.attempt, 0),
+    stage: oneOf(r.stage, VALID_TASK_STAGES, 'queued'),
+    message: asString(r.message, ''),
+    startedAt: asISODate(r.startedAt, now),
+    stageStartedAt: asISODate(r.stageStartedAt, now),
+    lastHeartbeatAt: asISODate(r.lastHeartbeatAt, now),
+    submittedAt: (() => { const v = r.submittedAt; return isValidISODate(v) ? v : undefined; })(),
+    conversationUrl: asNonEmptyString(r.conversationUrl) ?? undefined,
+    input: {
+      prompt: asString(isObject(input) ? input.prompt : '', ''),
+      mode: oneOf(isObject(input) ? input.mode : taskMode, VALID_GENERATION_MODES, taskMode),
+      videoConfig: isObject(videoConfig) ? normalizeVideoConfig(videoConfig) : undefined,
+      attachments: asStringArray(isObject(input) ? input.attachments : []),
+      audioAttachment: asNonEmptyString(isObject(input) ? input.audioAttachment : undefined) ?? undefined,
+    },
+  };
+}
+
+/**
+ * 归一化视频配置。
+ */
+function normalizeVideoConfig(raw: Record<string, unknown>): Task['videoConfig'] | undefined {
+  if (!isObject(raw)) return undefined;
+  return {
+    model: oneOf(raw.model, VALID_VIDEO_MODELS, 'seedance-2.0') as NonNullable<Task['videoConfig']>['model'],
+    duration: oneOf(raw.duration, VALID_VIDEO_DURATIONS, '10s') as NonNullable<Task['videoConfig']>['duration'],
+    aspectRatio: oneOf(raw.aspectRatio, VALID_VIDEO_ASPECT_RATIOS, '16:9') as NonNullable<Task['videoConfig']>['aspectRatio'],
+  };
+}
+
+/**
+ * 归一化单条运行历史记录。
+ */
+function normalizeRunRecord(raw: unknown, _now: string): TaskRunRecord | null {
+  if (!isObject(raw)) return null;
+  const r = raw;
+  const runId = asNonEmptyString(r.runId);
+  const startedAtRaw = r.startedAt;
+  const startedAt = isValidISODate(startedAtRaw) ? startedAtRaw : null;
+  if (!runId || !startedAt) return null;
+  const finishedAtRaw = r.finishedAt;
+
+  return {
+    runId,
+    attempt: asNonNegativeNumber(r.attempt, 0),
+    startedAt,
+    finishedAt: isValidISODate(finishedAtRaw) ? finishedAtRaw : undefined,
+    finalStage: optionalOneOf(r.finalStage, VALID_TASK_STAGES) as TaskRunRecord['finalStage'],
+    outcome: optionalOneOf(r.outcome, VALID_RUN_OUTCOMES) as TaskRunRecord['outcome'],
+    errorCode: typeof r.errorCode === 'string' ? r.errorCode : undefined,
+    durationMs: typeof r.durationMs === 'number' && r.durationMs >= 0 ? r.durationMs : undefined,
+  };
+}
+
+/**
+ * 归一化任务执行锁。
+ * 缺少必要字段时返回 undefined（丢弃无效锁）。
+ */
+function normalizeLock(raw: unknown, _now: string): TaskLock | undefined {
+  if (!isObject(raw)) return undefined;
+  const ownerId = asNonEmptyString(raw.ownerId);
+  const acquiredAtRaw = raw.acquiredAt;
+  const expiresAtRaw = raw.expiresAt;
+  const acquiredAt = isValidISODate(acquiredAtRaw) ? acquiredAtRaw : null;
+  const expiresAt = isValidISODate(expiresAtRaw) ? expiresAtRaw : null;
+  if (!ownerId || !acquiredAt || !expiresAt) return undefined;
+  return { ownerId, acquiredAt, expiresAt };
+}
+
+/**
+ * 在深拷贝的对象上执行任务字段归一化（直接修改传入对象）。
+ * 输入必须是 isObject 通过的对象。
+ */
+function normalizeTaskObject(raw: Record<string, unknown>, defaultProjectId: string, now: string): Task {
+  const task = raw as unknown as Task;
+
+  // 基础字段
+  const id = asNonEmptyString(raw.id);
+  task.id = id ?? `recovered-${now}-${Math.random().toString(36).slice(2, 10)}`;
+  task.prompt = asString(raw.prompt, '');
+  task.assignedAccountId = asNonEmptyString(raw.assignedAccountId) ?? null;
+  task.mode = oneOf(raw.mode, VALID_GENERATION_MODES, 'chat');
+  task.result = raw.result === null ? null : (typeof raw.result === 'string' ? raw.result : null);
+  task.source = oneOf(raw.source, VALID_TASK_SOURCES, 'manual') as Task['source'];
+  task.createdAt = asISODate(raw.createdAt, now);
+  task.updatedAt = asISODate(raw.updatedAt, now);
+
+  // 视频配置
+  task.videoConfig = isObject(raw.videoConfig) ? normalizeVideoConfig(raw.videoConfig) : undefined;
+
+  // 附件
+  task.attachments = asStringArray(raw.attachments).length > 0 ? asStringArray(raw.attachments) : undefined;
+  task.audioAttachment = asNonEmptyString(raw.audioAttachment) ?? undefined;
+
+  // 产物
+  task.outputs = asStringArray(raw.outputs);
+
+  // artifacts 归一化
+  const artifactResult = normalizeArtifacts(raw.artifacts, task.mode, now);
+  task.artifacts = artifactResult.artifacts;
+
+  // runHistory 归一化
+  if (Array.isArray(raw.runHistory)) {
+    task.runHistory = raw.runHistory
+      .map((item) => normalizeRunRecord(item, now))
+      .filter((r): r is TaskRunRecord => r !== null);
+  } else {
+    task.runHistory = [];
+  }
+
+  // 依赖
+  task.dependsOnTaskIds = asStringArray(raw.dependsOnTaskIds);
+  task.dependencyPolicy = optionalOneOf(raw.dependencyPolicy, VALID_DEPENDENCY_POLICIES) as DependencyPolicy | undefined;
+
+  // 项目 ID
+  task.projectId = asNonEmptyString(raw.projectId) ?? defaultProjectId;
+  task.batchId = asNonEmptyString(raw.batchId) ?? undefined;
+
+  // runtime / errorInfo / lock
+  task.runtime = normalizeRuntime(raw.runtime, task.mode, now);
+  task.errorInfo = normalizeErrorInfo(raw.errorInfo, now);
+  task.lock = normalizeLock(raw.lock, now);
+
+  // status 归一化：非法状态值标记为 fail 并保留原始状态信息
+  const rawStatus = raw.status;
+  if (typeof rawStatus === 'string' && (VALID_TASK_STATUSES as readonly string[]).includes(rawStatus)) {
+    task.status = rawStatus as TaskStatus;
+  } else {
+    // 非法状态 — 标记为 fail，保留原始错误信息
+    task.status = 'fail';
+    if (!task.errorInfo) {
+      task.errorInfo = {
+        code: 'unknown',
+        message: `任务状态异常，原始值「${typeof rawStatus === 'string' ? rawStatus : typeof rawStatus}」已归一化为 fail`,
+        recoverable: false,
+        detectedAt: now,
+      };
+    }
+  }
+
+  return task;
+}
+
+/**
+ * 归一化 tasks.json 原始数据。
+ *
+ * @param raw - readJSON 返回的原始数据
+ * @param defaultProjectId - 默认项目 ID（用于补全缺失的 projectId）
+ * @param now - 当前 ISO 时间字符串
+ * @returns 归一化结果
+ */
+export function normalizeTasks(
+  raw: unknown,
+  defaultProjectId: string,
+  now: string = new Date().toISOString(),
+): NormalizeResult<Task> {
+  // 顶层不是数组 — 安全回退为空数组，不覆盖原文件
+  if (!Array.isArray(raw)) {
+    return {
+      data: [],
+      changed: false,
+      warnings: ['tasks.json 顶层结构不是数组，已安全回退为空数组（不覆盖原文件）'],
+    };
+  }
+
+  // 深拷贝以避免修改输入
+  const cloned: unknown[] = JSON.parse(JSON.stringify(raw));
+  const originalJson = JSON.stringify(raw);
+  const warnings: string[] = [];
+  const seenIds = new Set<string>();
+  const result: Task[] = [];
+  let skippedCount = 0;
+
+  for (let i = 0; i < cloned.length; i++) {
+    const item = cloned[i];
+    if (!isObject(item)) {
+      skippedCount++;
+      warnings.push(`任务数组索引 ${i} 不是对象，已跳过`);
+      continue;
+    }
+    const task = normalizeTaskObject(item, defaultProjectId, now);
+    if (seenIds.has(task.id)) {
+      skippedCount++;
+      warnings.push(`跳过重复任务 ID「${task.id}」(索引 ${i})`);
+      continue;
+    }
+    seenIds.add(task.id);
+    result.push(task);
+  }
+
+  if (skippedCount > 0) {
+    warnings.push(`共跳过 ${skippedCount} 个无效或重复的任务项`);
+  }
+
+  const changed = JSON.stringify(result) !== originalJson;
+  return { data: result, changed, warnings };
+}
+
+// ==================== 下载记录归一化 ====================
+
+/**
+ * 在深拷贝的对象上执行下载记录字段归一化（直接修改传入对象）。
+ * 输入必须是 isObject 通过的对象。
+ */
+function normalizeDownloadJobObject(raw: Record<string, unknown>, now: string): DownloadJob {
+  const job = raw as unknown as DownloadJob;
+
+  job.id = asNonEmptyString(raw.id) ?? `recovered-${now}-${Math.random().toString(36).slice(2, 10)}`;
+  job.taskId = asString(raw.taskId, '');
+  job.accountId = asNonEmptyString(raw.accountId) ?? null;
+  job.mode = oneOf(raw.mode, VALID_GENERATION_MODES, 'chat');
+  job.url = asString(raw.url, '');
+  job.status = oneOf(raw.status, VALID_DOWNLOAD_STATUSES, 'failed') as DownloadJob['status'];
+  job.attempts = asNonNegativeNumber(raw.attempts, 0);
+  job.saveDir = asString(raw.saveDir, '');
+  job.filePath = asNonEmptyString(raw.filePath) ?? undefined;
+  job.bytes = typeof raw.bytes === 'number' && raw.bytes >= 0 ? raw.bytes : undefined;
+  job.error = asNonEmptyString(raw.error) ?? undefined;
+  job.createdAt = asISODate(raw.createdAt, now);
+  job.updatedAt = asISODate(raw.updatedAt, now);
+
+  return job;
+}
+
+/**
+ * 归一化 downloads.json 原始数据。
+ *
+ * 注意：此函数仅做结构和字段归一化，不做下载中断恢复。
+ * 下载中断恢复（将 'downloading' 标记为 'failed'）由调用方在归一化后单独执行，
+ * 因为该操作是进程级一次性操作。
+ *
+ * @param raw - readJSON 返回的原始数据
+ * @param now - 当前 ISO 时间字符串
+ * @returns 归一化结果
+ */
+export function normalizeDownloadJobs(
+  raw: unknown,
+  now: string = new Date().toISOString(),
+): NormalizeResult<DownloadJob> {
+  // 顶层不是数组 — 安全回退为空数组，不覆盖原文件
+  if (!Array.isArray(raw)) {
+    return {
+      data: [],
+      changed: false,
+      warnings: ['downloads.json 顶层结构不是数组，已安全回退为空数组（不覆盖原文件）'],
+    };
+  }
+
+  // 深拷贝以避免修改输入
+  const cloned: unknown[] = JSON.parse(JSON.stringify(raw));
+  const originalJson = JSON.stringify(raw);
+  const warnings: string[] = [];
+  const seenIds = new Set<string>();
+  const result: DownloadJob[] = [];
+  let skippedCount = 0;
+
+  for (let i = 0; i < cloned.length; i++) {
+    const item = cloned[i];
+    if (!isObject(item)) {
+      skippedCount++;
+      warnings.push(`下载数组索引 ${i} 不是对象，已跳过`);
+      continue;
+    }
+    const job = normalizeDownloadJobObject(item, now);
+    if (seenIds.has(job.id)) {
+      skippedCount++;
+      warnings.push(`跳过重复下载记录 ID「${job.id}」(索引 ${i})`);
+      continue;
+    }
+    seenIds.add(job.id);
+    result.push(job);
+  }
+
+  if (skippedCount > 0) {
+    warnings.push(`共跳过 ${skippedCount} 个无效或重复的下载记录项`);
+  }
+
+  const changed = JSON.stringify(result) !== originalJson;
+  return { data: result, changed, warnings };
+}

--- a/packages/contracts/src/enums.ts
+++ b/packages/contracts/src/enums.ts
@@ -63,10 +63,10 @@ export type TaskErrorCode =
   | 'unknown';
 
 /** 视频生成模型 */
-export type VideoModel = 'seedance-2.0' | 'seedance-2.0-fast' | 'seedance-2.0-mini';
+export type VideoModel = 'seedance-2.5' | 'seedance-2.0' | 'seedance-2.0-fast' | 'seedance-2.0-mini';
 
 /** 视频时长 */
-export type VideoDuration = '5s' | '10s' | '15s';
+export type VideoDuration = '4s' | '5s' | '6s' | '7s' | '8s' | '9s' | '10s' | '11s' | '12s' | '13s' | '14s' | '15s';
 
 /** 视频比例 */
 export type VideoAspectRatio = '1:1' | '3:4' | '4:3' | '9:16' | '16:9' | '21:9';

--- a/src/automation/doubaoAdapter.ts
+++ b/src/automation/doubaoAdapter.ts
@@ -1,11 +1,12 @@
 import type { AdapterRuleBundle, AdapterSelfCheckReport } from '../types';
 import type { WebviewHandle } from '../utils/doubaoBridge';
+import { buildDoubaoCapabilitySnapshot, DOUBAO_CAPABILITY_ADAPTER_VERSION } from './doubaoCapability';
 
-export const DOUBAO_ADAPTER_VERSION = '1.5.0-20260711';
+export const DOUBAO_ADAPTER_VERSION = DOUBAO_CAPABILITY_ADAPTER_VERSION;
 
 export const DEFAULT_ADAPTER_BUNDLE: AdapterRuleBundle = {
   version: DOUBAO_ADAPTER_VERSION,
-  createdAt: '2026-07-11T00:00:00.000Z',
+  createdAt: '2026-07-31T00:00:00.000Z',
   rules: {
     input: ['textarea', '[contenteditable="true"]'],
     submit: ['button[aria-label*="发送"]', 'button[aria-label*="send" i]', 'button[type="submit"]'],
@@ -67,22 +68,60 @@ export async function runAdapterSelfCheck(webview: WebviewHandle): Promise<Adapt
         return false;
       }
       var bodyText = document.body ? (document.body.innerText || '') : '';
+      var membershipText = '';
+      var dialogs = document.querySelectorAll('[role="dialog"], [aria-modal="true"]');
+      for (var d = 0; d < dialogs.length; d++) {
+        var dialogText = (dialogs[d].innerText || '').trim();
+        if (/购买会员|开通会员|升级会员|会员专享|仅限会员|权益不足/.test(dialogText)) {
+          membershipText = dialogText.slice(0, 500);
+          break;
+        }
+      }
+      var accountTier = 'unknown';
+      var tierMatch = bodyText.match(/(?:当前套餐|当前会员|会员等级)[:：\\s]*(免费|标准|加强|高级)(?:会员)?/);
+      if (tierMatch) accountTier = tierMatch[1];
       var checks = [
         { key: 'page', label: '豆包页面', ok: location.hostname.indexOf('doubao.com') >= 0, detail: location.pathname },
         { key: 'input', label: '提示词输入框', ok: any(rules.input), detail: any(rules.input) ? '已找到可见输入框' : '未找到 textarea/contenteditable' },
         { key: 'submit', label: '提交控件', ok: any(rules.submit) || bodyText.indexOf('发送') >= 0, detail: '按钮或发送文本检测' },
         { key: 'video_mode', label: '视频模式入口', ok: bodyText.indexOf('视频生成') >= 0 || bodyText.indexOf('生成视频') >= 0, detail: '页面文本能力检测' },
         { key: 'model', label: '模型配置', ok: bodyText.indexOf('Seedance') >= 0 || bodyText.indexOf('模型') >= 0, detail: '模型触发器检测' },
-        { key: 'duration', label: '时长配置', ok: /5s|10s|15s|5秒|10秒|15秒/.test(bodyText), detail: '时长选项检测' },
+        { key: 'duration', label: '时长配置', ok: /(?:1[0-5]|[4-9])\\s*(?:s|秒)/i.test(bodyText), detail: '4–15 秒页面选项检测' },
         { key: 'ratio', label: '比例配置', ok: /1:1|9:16|16:9|3:4|4:3|21:9/.test(bodyText), detail: '比例选项检测' },
         { key: 'upload', label: '素材上传', ok: document.querySelectorAll(rules.uploads[0]).length > 0 || bodyText.indexOf('参考图片') >= 0, detail: '文件输入控件检测' },
         { key: 'verification', label: '验证识别', ok: true, detail: '验证码 iframe、弹窗和关键词策略已加载' },
         { key: 'artifact', label: '产物识别', ok: true, detail: document.querySelectorAll('video, img').length + ' 个媒体节点可供扫描' }
       ];
-      return checks;
+      return { checks: checks, bodyText: bodyText.slice(0, 20000), membershipText: membershipText, accountTier: accountTier };
     })();
   `;
-  const items = await webview.executeJavaScript(code) as AdapterSelfCheckReport['items'];
+  const result = await webview.executeJavaScript(code) as {
+    checks: AdapterSelfCheckReport['items'];
+    bodyText: string;
+    membershipText: string;
+    accountTier: string;
+  };
+  const snapshot = buildDoubaoCapabilitySnapshot({
+    pageUrl: webview.getURL(),
+    bodyText: result.bodyText,
+    membershipDialogText: result.membershipText,
+    accountTier: result.accountTier,
+  });
+  const items = [
+    ...result.checks,
+    {
+      key: 'capability_snapshot',
+      label: '只读能力快照',
+      ok: snapshot.status !== 'unknown',
+      detail: JSON.stringify(snapshot),
+    },
+    {
+      key: 'final_submit',
+      label: '最终生成提交',
+      ok: true,
+      detail: 'dry-run：未点击最终生成、购买或升级控件',
+    },
+  ];
   const passed = items.filter((item) => item.ok).length;
   return {
     adapterVersion: bundle.version,

--- a/src/automation/doubaoCapability.ts
+++ b/src/automation/doubaoCapability.ts
@@ -1,0 +1,88 @@
+export const DOUBAO_CAPABILITY_ADAPTER_VERSION = '2.0.0-20260731';
+
+export type CapabilityAvailability = 'visible' | 'selectable' | 'action_required' | 'unknown';
+
+export interface DoubaoCapabilitySnapshot {
+  observed_at: string;
+  account_tier: string;
+  source: { kind: 'page'; url: string };
+  adapter_version: string;
+  status: 'observed' | 'partial' | 'unknown';
+  entries: string[];
+  video: {
+    models: string[];
+    durations: number[];
+    aspect_ratios: string[];
+  };
+  image: {
+    models: string[];
+    aspect_ratios: string[];
+  };
+  membership: {
+    availability: CapabilityAvailability;
+    evidence: string[];
+  };
+}
+
+export interface CapabilityObservation {
+  pageUrl: string;
+  bodyText: string;
+  observedAt?: string;
+  accountTier?: string;
+  membershipDialogText?: string;
+}
+
+const VIDEO_MODELS = ['Seedance 2.5', 'Seedance 2.0 Fast', 'Seedance 2.0 Mini', 'Seedance 2.0'];
+const IMAGE_MODELS = ['Seedream 5.0 Pro', 'Seedream 5.0 Lite', 'Seedream 4.5', 'Seedream 4.0'];
+const VIDEO_RATIOS = ['3:4', '4:3', '9:16', '16:9', '1:1', '21:9'];
+const IMAGE_RATIOS = ['9:16', '2:3', '3:4', '1:1', '4:3', '3:2', '16:9'];
+const ENTRY_LABELS = ['快速', '视频生成', '图像生成', 'PPT', '写作', '翻译', '深入研究', '录音转写', '更多'];
+const MEMBERSHIP_PATTERN = /购买会员|开通会员|升级会员|会员专享|仅限会员|权益不足/;
+
+function visibleLabels(text: string, candidates: readonly string[]): string[] {
+  return candidates.filter((label) => text.includes(label));
+}
+
+export function buildDoubaoCapabilitySnapshot(observation: CapabilityObservation): DoubaoCapabilitySnapshot {
+  const bodyText = observation.bodyText || '';
+  const dialogText = observation.membershipDialogText || '';
+  const durationMatches = Array.from(bodyText.matchAll(/(?:^|\D)(1[0-5]|[4-9])\s*(?:秒|s)(?=$|\D)/gi));
+  const durations = [...new Set(durationMatches.map((match) => Number(match[1])))].sort((a, b) => a - b);
+  const membershipEvidence = [dialogText, bodyText]
+    .filter((text) => MEMBERSHIP_PATTERN.test(text))
+    .map((text) => text.match(MEMBERSHIP_PATTERN)?.[0] || '会员动作');
+  const entries = visibleLabels(bodyText, ENTRY_LABELS);
+  const videoModels = visibleLabels(bodyText, VIDEO_MODELS);
+  const imageModels = visibleLabels(bodyText, IMAGE_MODELS);
+  const videoRatios = visibleLabels(bodyText, VIDEO_RATIOS);
+  const imageRatios = visibleLabels(bodyText, IMAGE_RATIOS);
+  const evidenceCount = entries.length + videoModels.length + imageModels.length + durations.length;
+
+  return {
+    observed_at: observation.observedAt || new Date().toISOString(),
+    account_tier: observation.accountTier?.trim() || 'unknown',
+    source: { kind: 'page', url: observation.pageUrl },
+    adapter_version: DOUBAO_CAPABILITY_ADAPTER_VERSION,
+    status: evidenceCount === 0 ? 'unknown' : evidenceCount < 4 ? 'partial' : 'observed',
+    entries,
+    video: { models: videoModels, durations, aspect_ratios: videoRatios },
+    image: { models: imageModels, aspect_ratios: imageRatios },
+    membership: {
+      availability: membershipEvidence.length > 0 ? 'action_required' : 'unknown',
+      evidence: [...new Set(membershipEvidence)],
+    },
+  };
+}
+
+export function evaluateDryRunSelection(
+  snapshot: DoubaoCapabilitySnapshot,
+  requested: { model: string; duration: number; aspectRatio: string },
+): { ok: boolean; code: 'ready' | 'membership_required' | 'ui_unsupported'; finalSubmit: false } {
+  if (requested.duration >= 11 && snapshot.membership.availability !== 'selectable') {
+    return { ok: false, code: 'membership_required', finalSubmit: false };
+  }
+  const known = snapshot.video.models.includes(requested.model)
+    && snapshot.video.durations.includes(requested.duration)
+    && snapshot.video.aspect_ratios.includes(requested.aspectRatio);
+  return { ok: known, code: known ? 'ready' : 'ui_unsupported', finalSubmit: false };
+}

--- a/src/components/BrowserPanel.tsx
+++ b/src/components/BrowserPanel.tsx
@@ -9,7 +9,7 @@
  */
 
 import React, { useRef, useEffect, useCallback, useState } from 'react';
-import { message, Switch, Tooltip } from 'antd';
+import { message, Tooltip } from 'antd';
 import type { Account, Task, TaskUpdateInput } from '../types';
 import { useAccountStore } from '../store/useAccountStore';
 import { useTaskStore } from '../store/useTaskStore';
@@ -29,8 +29,6 @@ import {
   configureVideoOptions,
   uploadReferenceImages,
   uploadReferenceAudio,
-  inject15sVideoPatch,
-  set15sVideoPatchEnabled,
   resetVideoCaptureCache,
   refreshBlockerBaseline,
   detectVideoGenerationBlocker,
@@ -83,14 +81,12 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
   const runningRef = useRef<Set<string>>(new Set());
   const abortControllersRef = useRef<Map<string, AbortController>>(new Map());
   const pendingRestartTasksRef = useRef<Map<string, TaskUpdateInput>>(new Map());
-  const manual15sRef = useRef<Record<string, boolean>>({});
   const manualVideoUsageRef = useRef<Set<string>>(new Set());
   /** 每个账号的定时器集合，用于组件卸载或账号删除时统一清理 */
   const timersRef = useRef<Map<string, Set<ReturnType<typeof setInterval> | ReturnType<typeof setTimeout>>>>(new Map());
 
   const [activeLoading, setActiveLoading] = useState(true);
   const [loadText, setLoadText] = useState('加载豆包中...');
-  const [manual15sByAccount, setManual15sByAccount] = useState<Record<string, boolean>>({});
   const [manualVideoExtracting, setManualVideoExtracting] = useState(false);
 
   const accountBusy = useTaskStore((s) => s.accountBusy);
@@ -250,9 +246,6 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
     webview.addEventListener('did-navigate-in-page', () => markLoaded('did-navigate-in-page'));
     webview.addEventListener('dom-ready', () => {
       markLoaded('dom-ready');
-      if (manual15sRef.current[accId]) {
-        void inject15sVideoPatch(webview).then(() => set15sVideoPatchEnabled(webview, true));
-      }
     });
     webview.addEventListener('did-fail-load', () => {
       loadingMapRef.current.set(accId, false);
@@ -334,29 +327,6 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
       }
     });
   }, [activeAccount?.id]);
-
-  const handleManual15sToggle = async (enabled: boolean) => {
-    if (!activeAccount) return;
-    const accountId = activeAccount.id;
-    const webview = registryRef.current.get(accountId);
-    if (!webview) {
-      message.error('当前账号页面尚未就绪');
-      return;
-    }
-
-    if (enabled) {
-      await inject15sVideoPatch(webview);
-    }
-    const ok = await set15sVideoPatchEnabled(webview, enabled);
-    if (!ok) {
-      message.error('15 秒脚本开关设置失败，请刷新页面后重试');
-      return;
-    }
-
-    manual15sRef.current[accountId] = enabled;
-    setManual15sByAccount((current) => ({ ...current, [accountId]: enabled }));
-    message.success(enabled ? '手动 15 秒脚本已开启' : '手动 15 秒脚本已关闭');
-  };
 
   const handleExtractCurrentVideo = async (): Promise<void> => {
     if (!activeAccount) return;
@@ -603,7 +573,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
             model: videoConfig.model,
             duration: videoConfig.duration,
             aspectRatio: videoConfig.aspectRatio,
-            manual15sEnabled: !!manual15sRef.current[accountId],
+            manual15sEnabled: false,
             seedanceQuota: account.seedanceQuota,
             health: account.health,
             scheduling: account.scheduling,
@@ -642,16 +612,8 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
           await pause(1500); // 等待 Tab 切换动画
         }
 
-        // 视频模式：配置参数 + 按需注入 15s 补丁
+        // 视频模式：只使用页面可见控件配置，禁止请求改写绕过会员门槛。
         if (mode === 'video') {
-          // 所有视频任务均安装网络监听；是否改写为 15 秒由独立开关控制。
-          const need15sPatch = videoConfig?.duration === '15s';
-          await inject15sVideoPatch(webview);
-          await set15sVideoPatchEnabled(webview, need15sPatch);
-          if (need15sPatch) {
-            setAccountAutomationState(accountId, 'injecting', '注入 15s 时长补丁...', 'configuring');
-            await pause(500);
-          }
           if (videoConfig) {
             setAccountAutomationState(accountId, 'injecting', '配置视频参数...', 'configuring');
             await configureVideoOptions(webview, videoConfig);
@@ -936,9 +898,6 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
     } finally {
       abortControllersRef.current.delete(taskId);
       pendingRestartTasksRef.current.delete(taskId);
-      if (mode === 'video') {
-        await set15sVideoPatchEnabled(webview, !!manual15sRef.current[accountId]);
-      }
       runningRef.current.delete(accountId);
       await automationEngine.release(taskId);
       setTimeout(() => useTaskStore.getState().processQueue(), 0);
@@ -1023,17 +982,6 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
               <path d="M12 3v12m0 0 4-4m-4 4-4-4M5 21h14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
             </svg>
           </button>
-        </Tooltip>
-        <Tooltip title="开启后，当前账号在页面中手动提交的视频请求会被改为 15 秒">
-          <div style={{ display: 'flex', alignItems: 'center', gap: 7, flexShrink: 0 }}>
-            <Switch
-              size="small"
-              checked={!!manual15sByAccount[activeAccount.id]}
-              disabled={!!accountBusy[activeAccount.id]}
-              onChange={handleManual15sToggle}
-            />
-            <span style={{ color: '#9898b8', fontSize: 12, whiteSpace: 'nowrap' }}>手动 15s</span>
-          </div>
         </Tooltip>
       </div>
 

--- a/src/components/TaskConsole.tsx
+++ b/src/components/TaskConsole.tsx
@@ -783,11 +783,10 @@ const TaskConsole: React.FC = () => {
             <Segmented
               value={videoConfig.duration}
               onChange={(val) => setVideoConfig({ ...videoConfig, duration: val as VideoDuration })}
-              options={[
-                { label: '5 秒', value: '5s' },
-                { label: '10 秒', value: '10s' },
-                { label: '15 秒', value: '15s' },
-              ]}
+              options={Array.from({ length: 12 }, (_, index) => {
+                const seconds = index + 4;
+                return { label: `${seconds} 秒`, value: `${seconds}s` };
+              })}
               block
               style={{ background: '#1a1a24', padding: '4px', borderRadius: 8, marginBottom: 12 }}
             />
@@ -1129,11 +1128,10 @@ const TaskConsole: React.FC = () => {
             <Segmented
               value={editingVideoConfig.duration}
               onChange={(value) => setEditingVideoConfig({ ...editingVideoConfig, duration: value as VideoDuration })}
-              options={[
-                { label: '5 秒', value: '5s' },
-                { label: '10 秒', value: '10s' },
-                { label: '15 秒', value: '15s' },
-              ]}
+              options={Array.from({ length: 12 }, (_, index) => {
+                const seconds = index + 4;
+                return { label: `${seconds} 秒`, value: `${seconds}s` };
+              })}
               block
               style={{ background: '#1a1a24', padding: 4, marginBottom: 12 }}
             />
@@ -1151,7 +1149,7 @@ const TaskConsole: React.FC = () => {
               const boundAccountId = editingTask?.assignedAccountId;
               if (!boundAccountId) {
                 // 未绑定账号时仅展示风险提示
-                if (editingVideoConfig.duration === '15s') {
+                if (Number.parseInt(editingVideoConfig.duration, 10) >= 11) {
                   return (
                     <div style={{
                       marginTop: 12,
@@ -1162,7 +1160,7 @@ const TaskConsole: React.FC = () => {
                       border: '1px solid rgba(250,173,20,0.3)',
                       color: '#faad14',
                     }}>
-                      15 秒时长可能受账号会员权益限制，提交后若被拒绝请更换配置重试
+                      11–15 秒必须在执行时取得页面实时可选证据；出现会员窗口或无法确认时将停止提交
                     </div>
                   );
                 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,12 +76,13 @@ export type {
 /** 视频配置默认值 */
 export const DEFAULT_VIDEO_CONFIG = {
   model: 'seedance-2.0' as VideoModel,
-  duration: '15s' as VideoDuration,
+  duration: '10s' as VideoDuration,
   aspectRatio: '16:9' as VideoAspectRatio,
 };
 
 /** 视频模型显示名映射 */
 export const VIDEO_MODEL_LABELS: Record<VideoModel, string> = {
+  'seedance-2.5': 'Seedance 2.5',
   'seedance-2.0': 'Seedance 2.0',
   'seedance-2.0-fast': 'Seedance 2.0 Fast',
   'seedance-2.0-mini': 'Seedance 2.0 Mini',
@@ -89,6 +90,7 @@ export const VIDEO_MODEL_LABELS: Record<VideoModel, string> = {
 
 /** 视频模型消耗说明 */
 export const VIDEO_MODEL_COST: Record<VideoModel, string> = {
+  'seedance-2.5': '页面实时显示',
   'seedance-2.0': '2 倍消耗',
   'seedance-2.0-fast': '快速出片',
   'seedance-2.0-mini': '日常使用',

--- a/src/utils/doubaoBridge.ts
+++ b/src/utils/doubaoBridge.ts
@@ -2636,6 +2636,7 @@ export async function configureVideoOptions(
 ): Promise<void> {
   // 模型名称映射（豆包页面显示的文本）
   const modelLabels: Record<string, string[]> = {
+    'seedance-2.5': ['Seedance 2.5', '2.5'],
     'seedance-2.0': ['Seedance 2.0', '2.0', '2.0 标准版', '标准', 'Standard'],
     'seedance-2.0-fast': ['Seedance 2.0 Fast', '2.0 Fast', 'Fast', '2.0 极速', '极速', '极速版', '2.0 Fast 极速'],
     'seedance-2.0-mini': ['Seedance 2.0 Mini', '2.0 Mini', 'Mini', '2.0 轻量', '轻量', '轻量版'],
@@ -3138,22 +3139,17 @@ export async function configureVideoOptions(
 
   // 1. 选择模型
   console.log(`[doubaoBridge] 配置视频模型: ${config.model}`);
-  const modelTriggers = ['模型', 'Mini', 'Fast', '2.0'];
+  const modelTriggers = ['模型', 'Mini', 'Fast', '2.5', '2.0'];
   if (!await selectDropdownOption(modelTriggers, modelTexts, '视频模型')) {
     throw new Error(`视频模型配置失败: ${config.model}`);
   }
   await sleep(400);
 
   // 2. 选择时长
-  const is15sPatch = config.duration === '15s';
-  if (is15sPatch) {
-    console.log(`[doubaoBridge] 配置视频时长: 15s（通过请求拦截实现，UI 跳过）`);
-  } else {
-    console.log(`[doubaoBridge] 配置视频时长: ${config.duration}`);
-    const durationTriggers = ['5s', '10s', '时长'];
-    if (!await selectDropdownOption(durationTriggers, durationTexts, '视频时长')) {
-      throw new Error(`视频时长配置失败: ${config.duration}`);
-    }
+  console.log(`[doubaoBridge] 配置视频时长: ${config.duration}（仅使用页面可见控件）`);
+  const durationTriggers = ['4s', '5s', '10s', '15s', '时长'];
+  if (!await selectDropdownOption(durationTriggers, durationTexts, '视频时长')) {
+    throw new Error(`视频时长配置失败: ${config.duration}`);
   }
   await sleep(300);
 
@@ -3433,6 +3429,10 @@ export async function uploadReferenceAudio(
  * 同时拦截 SSE 响应，提取 vid 和无水印视频地址存入 window.__doubaoVideoCache
  */
 export async function inject15sVideoPatch(webview: WebviewHandle): Promise<boolean> {
+  void webview;
+  console.warn('[doubaoBridge] 15 秒请求改写能力已永久禁用；必须使用页面实时控件');
+  return false;
+  /* istanbul ignore next -- 历史实现不可达，待独立清理包删除。 */
   const injectCode = `
     (function() {
       if (window.__doubao15sPatched) return;
@@ -3785,6 +3785,10 @@ export async function detectRobotVerification(webview: WebviewHandle): Promise<b
 
 /** 启用或关闭已经注入的 15 秒请求补丁。 */
 export async function set15sVideoPatchEnabled(webview: WebviewHandle, enabled: boolean): Promise<boolean> {
+  void webview;
+  void enabled;
+  return false;
+  /* istanbul ignore next -- 历史实现不可达。 */
   try {
     const result = await safeExecuteJS<boolean>(
       webview,

--- a/src/utils/videoCapability.ts
+++ b/src/utils/videoCapability.ts
@@ -4,7 +4,7 @@
  *
  * 职责：
  * 1. 在提交视频任务前，基于本地已知状态判断是否允许提交
- * 2. 对 15s + Seedance 2.0 Fast 等可能触发会员限制的配置给出中性风险提示
+ * 2. 对 11–15 秒配置要求页面实时能力证据，无法确认时 fail-closed
  * 3. 提供建议配置，但绝不自动替换用户配置
  *
  * 合规约束：
@@ -33,7 +33,7 @@ export type VideoCapabilityIssueCode =
   | 'verification_required'
   | 'scheduling_paused'
   | 'cooldown_active'
-  | 'membership_risk'
+  | 'membership_required'
   | 'account_error';
 
 /** 能力预检问题项 */
@@ -54,6 +54,8 @@ export interface VideoCapabilityInput {
   aspectRatio: VideoAspectRatio;
   /** 是否启用手动 15 秒补丁 */
   manual15sEnabled: boolean;
+  /** 页面实时观察结果；只有 selectable 能授权 11–15 秒继续配置。 */
+  platformAvailability?: 'selectable' | 'membership_required' | 'unknown';
   /** 账号本地额度状态（来自 Account.seedanceQuota） */
   seedanceQuota?: Account['seedanceQuota'];
   /** 账号健康状态（来自 Account.health） */
@@ -99,11 +101,10 @@ export interface VideoCapabilityResult {
  * 4. 调度暂停 → blocked
  * 5. 冷却中 → blocked
  * 6. 额度耗尽 → blocked
- * 7. 15s + Seedance 2.0 Fast → unknown（风险提示，不阻止提交）
+ * 7. 11–15 秒缺少页面可选证据或出现会员窗口 → blocked
  * 8. 其他情况 → allowed
  *
- * 会员资格不能仅凭本地推断为"可用"。未能确认时保持 unknown，允许正常提交，
- * 但提交后进入快速限制检测。
+ * 会员资格不能仅凭本地推断为"可用"。未能确认时必须 fail-closed。
  */
 export function evaluateVideoCapability(input: VideoCapabilityInput): VideoCapabilityResult {
   const now = input.now ?? Date.now();
@@ -176,12 +177,18 @@ export function evaluateVideoCapability(input: VideoCapabilityInput): VideoCapab
     });
   }
 
-  // ---- 7. 15s 时长风险提示 ----
-  // 15s 是本地注入能力，不能代表当前账号一定有平台侧生成资格。
-  // 特别是 15s + Seedance 2.0 Fast 组合可能触发会员/权益限制。
-  // 此处不阻止提交，仅给出中性风险提示。
-  const isFastRisk = input.duration === '15s' && input.model === 'seedance-2.0-fast';
-  const is15sRisk = input.duration === '15s';
+  // ---- 7. 11–15 秒实时能力门禁 ----
+  const durationSeconds = Number.parseInt(input.duration, 10);
+  const requiresLiveEntitlement = durationSeconds >= 11;
+  if (requiresLiveEntitlement && input.platformAvailability !== 'selectable') {
+    issues.push({
+      code: 'membership_required',
+      message: input.platformAvailability === 'membership_required'
+        ? '当前页面要求会员操作，已停止提交'
+        : '11–15 秒可能需要会员权益，缺少当前页面实时可选证据时禁止提交',
+      blocking: true,
+    });
+  }
 
   // ---- 确定最终状态 ----
   const blockingIssues = issues.filter((i) => i.blocking);
@@ -196,59 +203,13 @@ export function evaluateVideoCapability(input: VideoCapabilityInput): VideoCapab
       userMessage,
       canSubmit: false,
       // 提供建议配置（仅作为建议）
-      suggestion: is15sRisk
+      suggestion: requiresLiveEntitlement
         ? {
-            model: isFastRisk ? 'seedance-2.0' : input.model,
+            model: input.model,
             duration: '10s',
-            reason: isFastRisk
-              ? '当前配置可能受会员权益限制，可尝试使用 Seedance 2.0 + 10s 作为替代方案'
-              : '15 秒时长可能受部分账号会员权益限制，10 秒通常兼容性更好',
+            reason: '当前账户观察到 10 秒兼容性更好；仍应以页面实时能力为准',
           }
         : undefined,
-    };
-  }
-
-  if (isFastRisk) {
-    // 15s + Seedance 2.0 Fast：最高风险组合
-    return {
-      state: 'unknown',
-      issues: [
-        ...issues,
-        {
-          code: 'membership_risk',
-          message: '15 秒 + Seedance 2.0 Fast 组合可能受账号会员权益限制，提交后若被拒绝请更换配置重试',
-          blocking: false,
-        },
-      ],
-      userMessage: '15 秒 + Seedance 2.0 Fast 组合可能受账号会员权益限制，提交后若被拒绝请更换配置重试',
-      canSubmit: true,
-      suggestion: {
-        model: 'seedance-2.0',
-        duration: '10s',
-        reason: '如遇会员限制，可尝试使用 Seedance 2.0 + 10s 作为替代方案',
-      },
-    };
-  }
-
-  if (is15sRisk) {
-    // 15s + 其他模型：一般风险
-    return {
-      state: 'unknown',
-      issues: [
-        ...issues,
-        {
-          code: 'membership_risk',
-          message: '15 秒时长是本地注入能力，可能受账号会员权益限制，提交后若被拒绝请更换配置重试',
-          blocking: false,
-        },
-      ],
-      userMessage: '15 秒时长是本地注入能力，可能受账号会员权益限制，提交后若被拒绝请更换配置重试',
-      canSubmit: true,
-      suggestion: {
-        model: input.model,
-        duration: '10s',
-        reason: '15 秒时长可能受部分账号会员权益限制，10 秒通常兼容性更好',
-      },
     };
   }
 
@@ -269,21 +230,11 @@ export function suggestCompatibleVideoConfig(
   model: VideoModel,
   duration: VideoDuration,
 ): SuggestedVideoConfig | undefined {
-  // 15s + Seedance 2.0 Fast 是已知的高风险组合
-  if (duration === '15s' && model === 'seedance-2.0-fast') {
-    return {
-      model: 'seedance-2.0',
-      duration: '10s',
-      reason: '15 秒 + Seedance 2.0 Fast 可能受会员权益限制，Seedance 2.0 + 10s 通常兼容性更好',
-    };
-  }
-
-  // 15s + 任何模型在未知会员状态下都有一定风险
-  if (duration === '15s') {
+  if (Number.parseInt(duration, 10) >= 11) {
     return {
       model,
       duration: '10s',
-      reason: '15 秒时长可能受部分账号会员权益限制，10 秒通常兼容性更好',
+      reason: '11–15 秒需要页面实时能力证据；当前账户观察到 10 秒兼容性更好',
     };
   }
 

--- a/tests/unit/persistenceNormalization.test.ts
+++ b/tests/unit/persistenceNormalization.test.ts
@@ -1,0 +1,887 @@
+/**
+ * tests/unit/persistenceNormalization.test.ts
+ * 本地持久化数据运行时归一化回归测试
+ *
+ * 覆盖 accounts.json / tasks.json / downloads.json 的归一化逻辑：
+ * - 完整正常数据不产生变更
+ * - 缺失旧字段可补全为安全默认值
+ * - TaskErrorInfo.code 未知字符串保留
+ * - 非法 status、非法日期、负数额度的归一化
+ * - 顶层结构错误安全回退
+ * - 历史任务缺少字段可恢复读取
+ * - 重复 ID 去重
+ * - 归一化后对象满足所需字段
+ * - 不改变合法数据
+ * - 无变化不写盘、有变化才写盘
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeAccounts,
+  normalizeTasks,
+  normalizeDownloadJobs,
+  normalizeAccountQuota,
+  normalizeAccountHealth,
+  normalizeAccountScheduling,
+} from '../../main/utils/persistenceNormalization';
+import type { Account, Task, DownloadJob } from '@doubao-studio/contracts';
+
+// ==================== 测试常量 ====================
+
+const NOW = '2025-01-15T12:00:00.000Z';
+
+/** 与 persistenceNormalization 内部 localDateKeyFromISO 语义一致 */
+const nowDate = new Date(NOW);
+const TODAY = new Date(nowDate.getTime() - nowDate.getTimezoneOffset() * 60000)
+  .toISOString()
+  .slice(0, 10);
+
+const PAST_ISO = '2025-01-14T10:00:00.000Z';
+const FUTURE_ISO = '2025-01-16T10:00:00.000Z';
+const DEFAULT_PROJECT_ID = 'default-project';
+
+// ==================== Fixture 工厂 ====================
+
+/** 创建一个完整合法的 Account 对象（可被安全删除字段） */
+function makeValidAccount(): Account {
+  return {
+    id: 'acc-1',
+    name: '测试账号',
+    avatar: '',
+    partition: 'account_abc12345',
+    status: 'idle',
+    pinned: false,
+    seedanceQuota: {
+      date: TODAY,
+      usedUnits: 3,
+      estimatedTotalUnits: 10,
+      exhausted: false,
+      updatedAt: NOW,
+    },
+    health: {
+      loginState: 'ok',
+      verificationRequired: false,
+      consecutiveFailures: 0,
+      successCount: 5,
+      failureCount: 1,
+      lastSuccessAt: PAST_ISO,
+      lastFailureAt: PAST_ISO,
+      lastErrorCode: 'timeout',
+    },
+    scheduling: {
+      enabled: true,
+      weight: 1,
+      preferredModes: ['video'],
+    },
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: NOW,
+  };
+}
+
+/** 创建一个完整合法的 Task 对象 */
+function makeValidTask(): Task {
+  return {
+    id: 'task-1',
+    prompt: '测试提示词',
+    assignedAccountId: null,
+    status: 'queued',
+    mode: 'chat',
+    result: null,
+    outputs: [],
+    artifacts: [],
+    runHistory: [],
+    dependsOnTaskIds: [],
+    source: 'manual',
+    projectId: DEFAULT_PROJECT_ID,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: NOW,
+  };
+}
+
+/** 创建一个完整合法的 DownloadJob 对象 */
+function makeValidDownloadJob(): DownloadJob {
+  return {
+    id: 'dl-1',
+    taskId: 'task-1',
+    accountId: 'acc-1',
+    mode: 'video',
+    url: 'https://example.com/video.mp4',
+    status: 'done',
+    attempts: 1,
+    saveDir: '/downloads',
+    filePath: '/downloads/video.mp4',
+    bytes: 1024,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: NOW,
+  };
+}
+
+// ==================== normalizeAccounts ====================
+
+describe('normalizeAccounts', () => {
+  // ---- 测试 1: 完整正常数据不产生变更 ----
+  it('完整正常数据不产生变更', () => {
+    const account = makeValidAccount();
+    const result = normalizeAccounts([account], NOW);
+    expect(result.changed).toBe(false);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.data).toHaveLength(1);
+  });
+
+  it('归一化幂等性：对已归一化数据再次归一化不产生变更', () => {
+    const account = makeValidAccount();
+    const first = normalizeAccounts([account], NOW);
+    const second = normalizeAccounts(first.data, NOW);
+    expect(second.changed).toBe(false);
+  });
+
+  // ---- 测试 2: 缺失旧字段可补全为安全默认值 ----
+  it('缺失 seedanceQuota 时补全为今日空额度', () => {
+    const account = makeValidAccount();
+    delete (account as Partial<Account>).seedanceQuota;
+    const result = normalizeAccounts([account], NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].seedanceQuota).toBeDefined();
+    expect(result.data[0].seedanceQuota!.date).toBe(TODAY);
+    expect(result.data[0].seedanceQuota!.usedUnits).toBe(0);
+    expect(result.data[0].seedanceQuota!.estimatedTotalUnits).toBe(10);
+  });
+
+  it('缺失 health 时补全为安全默认值', () => {
+    const account = makeValidAccount();
+    delete (account as Partial<Account>).health;
+    const result = normalizeAccounts([account], NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].health).toBeDefined();
+    expect(result.data[0].health!.loginState).toBe('unknown');
+    expect(result.data[0].health!.consecutiveFailures).toBe(0);
+  });
+
+  it('缺失 scheduling 时补全为安全默认值', () => {
+    const account = makeValidAccount();
+    delete (account as Partial<Account>).scheduling;
+    const result = normalizeAccounts([account], NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].scheduling).toBeDefined();
+    expect(result.data[0].scheduling!.enabled).toBe(true);
+    expect(result.data[0].scheduling!.weight).toBe(1);
+  });
+
+  it('缺失 partition 时从 id 生成', () => {
+    const account = makeValidAccount();
+    account.id = 'acc-abc123';
+    delete (account as Partial<Account>).partition;
+    const result = normalizeAccounts([account], NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].partition).toBe('account_acc-abc1');
+  });
+
+  it('缺失 id 时生成 recovered ID', () => {
+    const account = makeValidAccount();
+    delete (account as Partial<Account>).id;
+    const result = normalizeAccounts([account], NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].id).toMatch(/^recovered-/);
+  });
+
+  // ---- 测试 4: 非法日期、负数额度归一化 ----
+  it('负数 usedUnits 归一化为 0', () => {
+    const account = makeValidAccount();
+    account.seedanceQuota = { date: TODAY, usedUnits: -5, estimatedTotalUnits: 10, exhausted: false, updatedAt: NOW };
+    const result = normalizeAccounts([account], NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].seedanceQuota!.usedUnits).toBe(0);
+  });
+
+  it('负数 estimatedTotalUnits 归一化为默认值', () => {
+    const account = makeValidAccount();
+    account.seedanceQuota = { date: TODAY, usedUnits: 3, estimatedTotalUnits: -1, exhausted: false, updatedAt: NOW };
+    const result = normalizeAccounts([account], NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].seedanceQuota!.estimatedTotalUnits).toBe(10);
+  });
+
+  it('额度日期为昨日时重置 usedUnits 为 0', () => {
+    const account = makeValidAccount();
+    account.seedanceQuota = { date: '2025-01-14', usedUnits: 8, estimatedTotalUnits: 10, exhausted: true, updatedAt: PAST_ISO };
+    const result = normalizeAccounts([account], NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].seedanceQuota!.date).toBe(TODAY);
+    expect(result.data[0].seedanceQuota!.usedUnits).toBe(0);
+    expect(result.data[0].seedanceQuota!.exhausted).toBe(false);
+  });
+
+  it('过期的 cooldownUntil 被清除', () => {
+    const account = makeValidAccount();
+    account.health = {
+      loginState: 'ok',
+      verificationRequired: true,
+      consecutiveFailures: 3,
+      successCount: 0,
+      failureCount: 3,
+      cooldownUntil: PAST_ISO,
+    };
+    const result = normalizeAccounts([account], NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].health!.cooldownUntil).toBeUndefined();
+    expect(result.data[0].health!.verificationRequired).toBe(false);
+  });
+
+  it('未过期的 cooldownUntil 保留', () => {
+    const account = makeValidAccount();
+    account.health = {
+      loginState: 'ok',
+      verificationRequired: true,
+      consecutiveFailures: 3,
+      successCount: 0,
+      failureCount: 3,
+      cooldownUntil: FUTURE_ISO,
+    };
+    const result = normalizeAccounts([account], NOW);
+    expect(result.data[0].health!.cooldownUntil).toBe(FUTURE_ISO);
+  });
+
+  it('非法 account status 归一化为 idle', () => {
+    const account: Record<string, unknown> = { ...makeValidAccount(), status: 'invalid_status' };
+    const result = normalizeAccounts([account], NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].status).toBe('idle');
+  });
+
+  it('非法 scheduling weight 裁剪到 [0.1, 10]', () => {
+    const account = makeValidAccount();
+    account.scheduling = { enabled: true, weight: 100, preferredModes: [] };
+    const result = normalizeAccounts([account], NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].scheduling!.weight).toBe(10);
+  });
+
+  it('非法 preferredModes 被过滤', () => {
+    const account: Record<string, unknown> = {
+      ...makeValidAccount(),
+      scheduling: { enabled: true, weight: 1, preferredModes: ['video', 'invalid_mode'] },
+    };
+    const result = normalizeAccounts([account], NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].scheduling!.preferredModes).toEqual(['video']);
+  });
+
+  it('非法 createdAt 归一化为 now', () => {
+    const account: Record<string, unknown> = { ...makeValidAccount(), createdAt: 'not-a-date' };
+    const result = normalizeAccounts([account], NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].createdAt).toBe(NOW);
+  });
+
+  // ---- 测试 5: 顶层不是数组、数组项不是对象 ----
+  it('顶层不是数组时安全回退为空数组且不覆盖原文件', () => {
+    const result = normalizeAccounts({ foo: 'bar' }, NOW);
+    expect(result.data).toEqual([]);
+    expect(result.changed).toBe(false);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('数组项不是对象时安全跳过', () => {
+    const result = normalizeAccounts(['string', 42, null, makeValidAccount()], NOW);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].id).toBe('acc-1');
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  // ---- 测试 7: 重复账号 ID 去重 ----
+  it('重复账号 ID 只保留第一个', () => {
+    const acc1 = makeValidAccount();
+    acc1.id = 'dup-id'; acc1.name = '账号1';
+    const acc2 = makeValidAccount();
+    acc2.id = 'dup-id'; acc2.name = '账号2';
+    const result = normalizeAccounts([acc1, acc2], NOW);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].name).toBe('账号1');
+    expect(result.warnings.some((w) => w.includes('重复'))).toBe(true);
+  });
+
+  // ---- 测试 8: 归一化后对象满足所需字段 ----
+  it('归一化后账号满足 Account 接口所有必填字段', () => {
+    const minimal: Record<string, unknown> = { id: 'acc-min' };
+    const result = normalizeAccounts([minimal], NOW);
+    const acc = result.data[0];
+    expect(typeof acc.id).toBe('string');
+    expect(typeof acc.name).toBe('string');
+    expect(typeof acc.avatar).toBe('string');
+    expect(typeof acc.partition).toBe('string');
+    expect(typeof acc.status).toBe('string');
+    expect(typeof acc.pinned).toBe('boolean');
+    expect(typeof acc.createdAt).toBe('string');
+    expect(typeof acc.updatedAt).toBe('string');
+    expect(acc.seedanceQuota).toBeDefined();
+    expect(acc.health).toBeDefined();
+    expect(acc.scheduling).toBeDefined();
+  });
+
+  // ---- 测试 9: 不改变合法数据 ----
+  it('不改变合法账号名称、头像、partition', () => {
+    const account = makeValidAccount();
+    account.name = '我的账号';
+    account.avatar = 'https://example.com/avatar.png';
+    account.partition = 'account_mypartition';
+    const result = normalizeAccounts([account], NOW);
+    expect(result.data[0].name).toBe('我的账号');
+    expect(result.data[0].avatar).toBe('https://example.com/avatar.png');
+    expect(result.data[0].partition).toBe('account_mypartition');
+  });
+
+  // ---- 测试 10: 无变化不写盘、有变化才写盘 ----
+  it('完整正常数据 changed=false（不触发写盘）', () => {
+    const result = normalizeAccounts([makeValidAccount()], NOW);
+    expect(result.changed).toBe(false);
+  });
+
+  it('缺失字段时 changed=true（触发写盘）', () => {
+    const account = makeValidAccount();
+    delete (account as Partial<Account>).seedanceQuota;
+    const result = normalizeAccounts([account], NOW);
+    expect(result.changed).toBe(true);
+  });
+});
+
+// ==================== normalizeAccountQuota / Health / Scheduling 导出函数 ====================
+
+describe('normalizeAccountQuota', () => {
+  it('日期非今日时重置额度', () => {
+    const account = makeValidAccount();
+    account.seedanceQuota = { date: '2025-01-10', usedUnits: 5, estimatedTotalUnits: 10, exhausted: true, updatedAt: PAST_ISO };
+    normalizeAccountQuota(account, NOW);
+    expect(account.seedanceQuota!.date).toBe(TODAY);
+    expect(account.seedanceQuota!.usedUnits).toBe(0);
+    expect(account.seedanceQuota!.exhausted).toBe(false);
+  });
+
+  it('保留正数 estimatedTotalUnits 在跨日重置时', () => {
+    const account = makeValidAccount();
+    account.seedanceQuota = { date: '2025-01-10', usedUnits: 5, estimatedTotalUnits: 20, exhausted: false, updatedAt: PAST_ISO };
+    normalizeAccountQuota(account, NOW);
+    expect(account.seedanceQuota!.estimatedTotalUnits).toBe(20);
+  });
+});
+
+describe('normalizeAccountHealth', () => {
+  it('lastErrorCode 为未知字符串时保留', () => {
+    const account = makeValidAccount();
+    account.health = {
+      loginState: 'ok',
+      verificationRequired: false,
+      consecutiveFailures: 1,
+      successCount: 0,
+      failureCount: 1,
+      lastErrorCode: 'some_unknown_error_code',
+    };
+    normalizeAccountHealth(account, NOW);
+    expect(account.health!.lastErrorCode).toBe('some_unknown_error_code');
+  });
+
+  it('非法 loginState 归一化为 unknown', () => {
+    const account = makeValidAccount();
+    account.health = {
+      loginState: 'invalid' as 'unknown',
+      verificationRequired: false,
+      consecutiveFailures: 0,
+      successCount: 0,
+      failureCount: 0,
+    };
+    normalizeAccountHealth(account, NOW);
+    expect(account.health!.loginState).toBe('unknown');
+  });
+
+  it('负数 consecutiveFailures 归一化为 0', () => {
+    const account = makeValidAccount();
+    account.health = {
+      loginState: 'ok',
+      verificationRequired: false,
+      consecutiveFailures: -3,
+      successCount: -1,
+      failureCount: -2,
+    };
+    normalizeAccountHealth(account, NOW);
+    expect(account.health!.consecutiveFailures).toBe(0);
+    expect(account.health!.successCount).toBe(0);
+    expect(account.health!.failureCount).toBe(0);
+  });
+});
+
+describe('normalizeAccountScheduling', () => {
+  it('过期的 manualCooldownUntil 被清除', () => {
+    const account = makeValidAccount();
+    account.scheduling = { enabled: true, weight: 1, preferredModes: [], manualCooldownUntil: PAST_ISO };
+    normalizeAccountScheduling(account, NOW);
+    expect(account.scheduling!.manualCooldownUntil).toBeUndefined();
+  });
+
+  it('未过期的 manualCooldownUntil 保留', () => {
+    const account = makeValidAccount();
+    account.scheduling = { enabled: true, weight: 1, preferredModes: [], manualCooldownUntil: FUTURE_ISO };
+    normalizeAccountScheduling(account, NOW);
+    expect(account.scheduling!.manualCooldownUntil).toBe(FUTURE_ISO);
+  });
+});
+
+// ==================== normalizeTasks ====================
+
+describe('normalizeTasks', () => {
+  // ---- 测试 1: 完整正常数据不产生变更 ----
+  it('完整正常数据不产生变更', () => {
+    const task = makeValidTask();
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.changed).toBe(false);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.data).toHaveLength(1);
+  });
+
+  it('归一化幂等性', () => {
+    const task = makeValidTask();
+    const first = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    const second = normalizeTasks(first.data, DEFAULT_PROJECT_ID, NOW);
+    expect(second.changed).toBe(false);
+  });
+
+  // ---- 测试 2: 缺失旧字段可补全 ----
+  it('缺失 mode 时补全为 chat', () => {
+    const task = makeValidTask();
+    delete (task as Partial<Task>).mode;
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].mode).toBe('chat');
+  });
+
+  it('缺失 source 时补全为 manual', () => {
+    const task = makeValidTask();
+    delete (task as Partial<Task>).source;
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].source).toBe('manual');
+  });
+
+  it('缺失 outputs 时补全为空数组', () => {
+    const task = makeValidTask();
+    delete (task as Partial<Task>).outputs;
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].outputs).toEqual([]);
+  });
+
+  // ---- 测试 3: TaskErrorInfo.code 未知字符串保留 ----
+  it('TaskErrorInfo.code 为未知字符串时保留不抛错', () => {
+    const task = makeValidTask();
+    task.status = 'fail';
+    task.errorInfo = {
+      code: 'totally_unknown_error',
+      message: '未知错误',
+      recoverable: true,
+      detectedAt: NOW,
+    };
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.data[0].errorInfo).toBeDefined();
+    expect(result.data[0].errorInfo!.code).toBe('totally_unknown_error');
+  });
+
+  it('errorInfo.code 为已知错误码时正常保留', () => {
+    const task = makeValidTask();
+    task.status = 'fail';
+    task.errorInfo = {
+      code: 'timeout',
+      message: '请求超时',
+      recoverable: true,
+      detectedAt: NOW,
+    };
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.data[0].errorInfo!.code).toBe('timeout');
+  });
+
+  // ---- 测试 4: 非法 status、非法日期、负数 ----
+  it('非法 status 归一化为 fail 并保留原始错误信息', () => {
+    const task: Record<string, unknown> = { ...makeValidTask(), status: 'invalid_status' };
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].status).toBe('fail');
+    expect(result.data[0].errorInfo).toBeDefined();
+    expect(result.data[0].errorInfo!.message).toContain('invalid_status');
+  });
+
+  it('非法 status 但已有 errorInfo 时保留原有 errorInfo', () => {
+    const task: Record<string, unknown> = {
+      ...makeValidTask(),
+      status: 'invalid_status',
+      errorInfo: { code: 'custom_error', message: '原始错误', recoverable: false, detectedAt: NOW },
+    };
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.data[0].status).toBe('fail');
+    expect(result.data[0].errorInfo!.code).toBe('custom_error');
+    expect(result.data[0].errorInfo!.message).toBe('原始错误');
+  });
+
+  it('非法 createdAt 归一化为 now', () => {
+    const task: Record<string, unknown> = { ...makeValidTask(), createdAt: 'not-a-date' };
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].createdAt).toBe(NOW);
+  });
+
+  it('非法 updatedAt 归一化为 now', () => {
+    const task: Record<string, unknown> = { ...makeValidTask(), updatedAt: 12345 };
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].updatedAt).toBe(NOW);
+  });
+
+  it('非法 mode 归一化为 chat', () => {
+    const task: Record<string, unknown> = { ...makeValidTask(), mode: 'unknown_mode' };
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].mode).toBe('chat');
+  });
+
+  // ---- 测试 5: 顶层不是数组、数组项不是对象 ----
+  it('顶层不是数组时安全回退为空数组', () => {
+    const result = normalizeTasks({ error: true }, DEFAULT_PROJECT_ID, NOW);
+    expect(result.data).toEqual([]);
+    expect(result.changed).toBe(false);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('任务数组项不是对象时安全跳过', () => {
+    const result = normalizeTasks([42, 'string', null, makeValidTask()], DEFAULT_PROJECT_ID, NOW);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].id).toBe('task-1');
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  // ---- 测试 6: 历史任务缺少字段可恢复 ----
+  it('缺失 projectId 时补全为默认项目 ID', () => {
+    const task = makeValidTask();
+    delete (task as Partial<Task>).projectId;
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].projectId).toBe(DEFAULT_PROJECT_ID);
+  });
+
+  it('缺失 artifacts 时补全为空数组', () => {
+    const task = makeValidTask();
+    delete (task as Partial<Task>).artifacts;
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].artifacts).toEqual([]);
+  });
+
+  it('缺失 runHistory 时补全为空数组', () => {
+    const task = makeValidTask();
+    delete (task as Partial<Task>).runHistory;
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].runHistory).toEqual([]);
+  });
+
+  it('缺失 dependsOnTaskIds 时补全为空数组', () => {
+    const task = makeValidTask();
+    delete (task as Partial<Task>).dependsOnTaskIds;
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].dependsOnTaskIds).toEqual([]);
+  });
+
+  it('极简任务（只有 id 和 prompt）可恢复读取', () => {
+    const result = normalizeTasks([{ id: 'min-task', prompt: 'hello' }], DEFAULT_PROJECT_ID, NOW);
+    expect(result.data).toHaveLength(1);
+    const task = result.data[0];
+    expect(task.id).toBe('min-task');
+    expect(task.prompt).toBe('hello');
+    // 缺失 status 时归一化为 fail（安全回退），但保留 id 和提示词
+    expect(task.status).toBe('fail');
+    expect(task.errorInfo).toBeDefined();
+    expect(task.mode).toBe('chat');
+    expect(task.outputs).toEqual([]);
+    expect(task.artifacts).toEqual([]);
+    expect(task.runHistory).toEqual([]);
+    expect(task.dependsOnTaskIds).toEqual([]);
+    expect(task.projectId).toBe(DEFAULT_PROJECT_ID);
+  });
+
+  // ---- 测试 7: 重复任务 ID 去重 ----
+  it('重复任务 ID 只保留第一个且记录警告', () => {
+    const t1 = makeValidTask(); t1.id = 'dup-task'; t1.prompt = '任务1';
+    const t2 = makeValidTask(); t2.id = 'dup-task'; t2.prompt = '任务2';
+    const result = normalizeTasks([t1, t2], DEFAULT_PROJECT_ID, NOW);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].prompt).toBe('任务1');
+    expect(result.warnings.some((w) => w.includes('dup-task'))).toBe(true);
+  });
+
+  // ---- 测试 8: 归一化后对象满足所需字段 ----
+  it('归一化后任务满足 Task 接口所有必填字段', () => {
+    const result = normalizeTasks([{ id: 'min', prompt: 'p' }], DEFAULT_PROJECT_ID, NOW);
+    const task = result.data[0];
+    expect(typeof task.id).toBe('string');
+    expect(typeof task.prompt).toBe('string');
+    expect(task.assignedAccountId).toBeNull();
+    expect(typeof task.status).toBe('string');
+    expect(typeof task.mode).toBe('string');
+    expect(task.result).toBeNull();
+    expect(Array.isArray(task.outputs)).toBe(true);
+    expect(Array.isArray(task.artifacts)).toBe(true);
+    expect(Array.isArray(task.runHistory)).toBe(true);
+    expect(Array.isArray(task.dependsOnTaskIds)).toBe(true);
+    expect(typeof task.projectId).toBe('string');
+    expect(typeof task.createdAt).toBe('string');
+    expect(typeof task.updatedAt).toBe('string');
+  });
+
+  // ---- 测试 9: 不改变合法附件、提示词、产物 URL ----
+  it('不改变合法提示词', () => {
+    const task = makeValidTask();
+    task.prompt = '这是一条很长的提示词，用于测试归一化不修改原始内容。';
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.data[0].prompt).toBe('这是一条很长的提示词，用于测试归一化不修改原始内容。');
+  });
+
+  it('不改变合法附件路径', () => {
+    const task = makeValidTask();
+    task.attachments = ['/path/to/image1.png', '/path/to/image2.jpg'];
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.data[0].attachments).toEqual(['/path/to/image1.png', '/path/to/image2.jpg']);
+  });
+
+  it('不改变合法产物 URL', () => {
+    const task = makeValidTask();
+    task.outputs = ['https://example.com/output1.mp4', 'https://example.com/output2.mp4'];
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.data[0].outputs).toEqual(['https://example.com/output1.mp4', 'https://example.com/output2.mp4']);
+  });
+
+  it('不改变合法 artifacts URL', () => {
+    const task = makeValidTask();
+    task.artifacts = [{
+      id: 'art-1',
+      url: 'https://example.com/video.mp4',
+      kind: 'video',
+      source: 'network',
+      runId: 'run-1',
+      discoveredAt: NOW,
+    }];
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.data[0].artifacts).toHaveLength(1);
+    expect(result.data[0].artifacts![0].url).toBe('https://example.com/video.mp4');
+  });
+
+  // ---- 测试 10: 无变化不写盘、有变化才写盘 ----
+  it('完整正常任务 changed=false', () => {
+    const result = normalizeTasks([makeValidTask()], DEFAULT_PROJECT_ID, NOW);
+    expect(result.changed).toBe(false);
+  });
+
+  it('缺失字段时 changed=true', () => {
+    const task = makeValidTask();
+    delete (task as Partial<Task>).projectId;
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.changed).toBe(true);
+  });
+
+  // ---- 附件列表安全回退 ----
+  it('损坏的附件列表（非数组）归一化为空数组', () => {
+    const task: Record<string, unknown> = { ...makeValidTask(), attachments: 'not-an-array' };
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.data[0].attachments).toBeUndefined();
+  });
+
+  it('附件数组含非字符串项时过滤', () => {
+    const task: Record<string, unknown> = { ...makeValidTask(), attachments: ['valid.png', 42, null, 'valid2.jpg'] };
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.data[0].attachments).toEqual(['valid.png', 'valid2.jpg']);
+  });
+
+  // ---- artifacts 去重 ----
+  it('重复 URL 的 artifacts 去重', () => {
+    const task = makeValidTask();
+    task.artifacts = [
+      { id: 'a1', url: 'https://example.com/dup.mp4', kind: 'video', source: 'network', discoveredAt: NOW },
+      { id: 'a2', url: 'https://example.com/dup.mp4', kind: 'video', source: 'page', discoveredAt: NOW },
+    ];
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.data[0].artifacts).toHaveLength(1);
+    expect(result.data[0].artifacts![0].id).toBe('a1');
+  });
+
+  // ---- runtime 归一化 ----
+  it('runtime 缺失时设为 undefined', () => {
+    const task = makeValidTask();
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.data[0].runtime).toBeUndefined();
+  });
+
+  it('runtime 含合法字段时保留', () => {
+    const task = makeValidTask();
+    task.runtime = {
+      runId: 'run-1',
+      attempt: 1,
+      stage: 'generating',
+      message: '生成中',
+      startedAt: NOW,
+      stageStartedAt: NOW,
+      lastHeartbeatAt: NOW,
+      input: { prompt: '测试', mode: 'chat', attachments: [] },
+    };
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.data[0].runtime).toBeDefined();
+    expect(result.data[0].runtime!.runId).toBe('run-1');
+    expect(result.data[0].runtime!.stage).toBe('generating');
+  });
+
+  // ---- lock 归一化 ----
+  it('lock 缺少必要字段时丢弃', () => {
+    const task: Record<string, unknown> = { ...makeValidTask(), lock: { ownerId: 'owner1' } };
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.data[0].lock).toBeUndefined();
+  });
+
+  it('lock 字段完整时保留', () => {
+    const task = makeValidTask();
+    task.lock = { ownerId: 'owner1', acquiredAt: NOW, expiresAt: FUTURE_ISO };
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.data[0].lock).toBeDefined();
+    expect(result.data[0].lock!.ownerId).toBe('owner1');
+  });
+
+  // ---- videoConfig 归一化 ----
+  it('非法 videoConfig model 归一化为默认值', () => {
+    const task: Record<string, unknown> = {
+      ...makeValidTask(),
+      mode: 'video',
+      videoConfig: { model: 'unknown-model', duration: '10s', aspectRatio: '16:9' },
+    };
+    const result = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].videoConfig!.model).toBe('seedance-2.0');
+  });
+});
+
+// ==================== normalizeDownloadJobs ====================
+
+describe('normalizeDownloadJobs', () => {
+  // ---- 测试 1: 完整正常数据不产生变更 ----
+  it('完整正常数据不产生变更', () => {
+    const job = makeValidDownloadJob();
+    const result = normalizeDownloadJobs([job], NOW);
+    expect(result.changed).toBe(false);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('归一化幂等性', () => {
+    const job = makeValidDownloadJob();
+    const first = normalizeDownloadJobs([job], NOW);
+    const second = normalizeDownloadJobs(first.data, NOW);
+    expect(second.changed).toBe(false);
+  });
+
+  // ---- 测试 2: 缺失字段补全 ----
+  it('缺失 attempts 时补全为 0', () => {
+    const job = makeValidDownloadJob();
+    delete (job as Partial<DownloadJob>).attempts;
+    const result = normalizeDownloadJobs([job], NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].attempts).toBe(0);
+  });
+
+  it('缺失 status 时补全为 failed', () => {
+    const job = makeValidDownloadJob();
+    delete (job as Partial<DownloadJob>).status;
+    const result = normalizeDownloadJobs([job], NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].status).toBe('failed');
+  });
+
+  // ---- 测试 4: 非法值归一化 ----
+  it('非法 status 归一化为 failed', () => {
+    const job: Record<string, unknown> = { ...makeValidDownloadJob(), status: 'invalid' };
+    const result = normalizeDownloadJobs([job], NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].status).toBe('failed');
+  });
+
+  it('负数 attempts 归一化为 0', () => {
+    const job = makeValidDownloadJob();
+    job.attempts = -5;
+    const result = normalizeDownloadJobs([job], NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].attempts).toBe(0);
+  });
+
+  it('非法 createdAt 归一化为 now', () => {
+    const job: Record<string, unknown> = { ...makeValidDownloadJob(), createdAt: 'not-a-date' };
+    const result = normalizeDownloadJobs([job], NOW);
+    expect(result.changed).toBe(true);
+    expect(result.data[0].createdAt).toBe(NOW);
+  });
+
+  // ---- 测试 5: 顶层结构错误 ----
+  it('顶层不是数组时安全回退', () => {
+    const result = normalizeDownloadJobs({ error: true }, NOW);
+    expect(result.data).toEqual([]);
+    expect(result.changed).toBe(false);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('下载数组项不是对象时安全跳过', () => {
+    const result = normalizeDownloadJobs([42, null, makeValidDownloadJob()], NOW);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].id).toBe('dl-1');
+  });
+
+  // ---- 测试 7: 重复 ID 去重 ----
+  it('重复下载 ID 只保留第一个', () => {
+    const j1 = makeValidDownloadJob(); j1.id = 'dup-dl'; j1.url = 'https://a.com/1.mp4';
+    const j2 = makeValidDownloadJob(); j2.id = 'dup-dl'; j2.url = 'https://a.com/2.mp4';
+    const result = normalizeDownloadJobs([j1, j2], NOW);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].url).toBe('https://a.com/1.mp4');
+  });
+
+  // ---- 测试 8: 归一化后满足字段 ----
+  it('归一化后下载记录满足 DownloadJob 必填字段', () => {
+    const result = normalizeDownloadJobs([{ id: 'min-dl' }], NOW);
+    const job = result.data[0];
+    expect(typeof job.id).toBe('string');
+    expect(typeof job.taskId).toBe('string');
+    expect(job.accountId).toBeNull();
+    expect(typeof job.mode).toBe('string');
+    expect(typeof job.url).toBe('string');
+    expect(typeof job.status).toBe('string');
+    expect(typeof job.attempts).toBe('number');
+    expect(typeof job.saveDir).toBe('string');
+    expect(typeof job.createdAt).toBe('string');
+    expect(typeof job.updatedAt).toBe('string');
+  });
+
+  // ---- 测试 9: 不改变合法数据 ----
+  it('不改变合法 URL、saveDir、filePath', () => {
+    const job = makeValidDownloadJob();
+    job.url = 'https://example.com/output.mp4';
+    job.saveDir = '/my/downloads';
+    job.filePath = '/my/downloads/output.mp4';
+    job.bytes = 999999;
+    const result = normalizeDownloadJobs([job], NOW);
+    expect(result.data[0].url).toBe('https://example.com/output.mp4');
+    expect(result.data[0].saveDir).toBe('/my/downloads');
+    expect(result.data[0].filePath).toBe('/my/downloads/output.mp4');
+    expect(result.data[0].bytes).toBe(999999);
+  });
+
+  // ---- 测试 10: 无变化不写盘 ----
+  it('完整正常数据 changed=false', () => {
+    const result = normalizeDownloadJobs([makeValidDownloadJob()], NOW);
+    expect(result.changed).toBe(false);
+  });
+
+  it('缺失字段时 changed=true', () => {
+    const job = makeValidDownloadJob();
+    delete (job as Partial<DownloadJob>).status;
+    const result = normalizeDownloadJobs([job], NOW);
+    expect(result.changed).toBe(true);
+  });
+});

--- a/tests/unit/videoCapability.test.ts
+++ b/tests/unit/videoCapability.test.ts
@@ -12,6 +12,8 @@ import {
 } from '../../src/utils/videoCapability';
 import type { VideoCapabilityInput } from '../../src/utils/videoCapability';
 import type { SeedanceQuota, AccountHealth, AccountScheduling, AccountStatus } from '../../src/types';
+import { buildDoubaoCapabilitySnapshot, evaluateDryRunSelection } from '../../src/automation/doubaoCapability';
+import { inject15sVideoPatch, set15sVideoPatchEnabled } from '../../src/utils/doubaoBridge';
 
 // ==================== 测试数据工厂 ====================
 
@@ -136,9 +138,8 @@ describe('evaluateVideoCapability', () => {
     });
   });
 
-  // ---- 测试 3: 15s + Seedance 2.0 Fast 在未知会员状态下返回可提交但带风险提示 ----
-  describe('15s + Seedance 2.0 Fast 风险提示', () => {
-    it('15s + seedance-2.0-fast 在健康账号下返回 unknown（可提交）', () => {
+  describe('11–15s 页面实时能力门禁', () => {
+    it('15s + seedance-2.0-fast 缺少实时证据时 fail-closed', () => {
       const input = makeBaseInput({
         model: 'seedance-2.0-fast',
         duration: '15s',
@@ -148,10 +149,9 @@ describe('evaluateVideoCapability', () => {
         accountStatus: healthyAccountStatus,
       });
       const result = evaluateVideoCapability(input);
-      expect(result.state).toBe('unknown');
-      expect(result.canSubmit).toBe(true);
-      expect(result.issues.some(i => i.code === 'membership_risk' && !i.blocking)).toBe(true);
-      expect(result.userMessage).toContain('会员权益限制');
+      expect(result.state).toBe('blocked');
+      expect(result.canSubmit).toBe(false);
+      expect(result.issues.some(i => i.code === 'membership_required' && i.blocking)).toBe(true);
     });
 
     it('15s + seedance-2.0-fast 提供建议配置但不改变原始配置', () => {
@@ -165,14 +165,14 @@ describe('evaluateVideoCapability', () => {
       });
       const result = evaluateVideoCapability(input);
       expect(result.suggestion).toBeDefined();
-      expect(result.suggestion!.model).toBe('seedance-2.0');
+      expect(result.suggestion!.model).toBe('seedance-2.0-fast');
       expect(result.suggestion!.duration).toBe('10s');
       // 原始输入不被修改
       expect(input.model).toBe('seedance-2.0-fast');
       expect(input.duration).toBe('15s');
     });
 
-    it('15s + 非 Fast 模型在健康账号下返回 unknown', () => {
+    it('页面明确出现会员动作时返回 blocked', () => {
       const input = makeBaseInput({
         model: 'seedance-2.0',
         duration: '15s',
@@ -180,11 +180,17 @@ describe('evaluateVideoCapability', () => {
         health: healthyHealth,
         scheduling: healthyScheduling,
         accountStatus: healthyAccountStatus,
+        platformAvailability: 'membership_required',
       });
       const result = evaluateVideoCapability(input);
-      expect(result.state).toBe('unknown');
+      expect(result.state).toBe('blocked');
+      expect(result.canSubmit).toBe(false);
+    });
+
+    it('只有页面实时确认 selectable 时允许 11s', () => {
+      const result = evaluateVideoCapability(makeBaseInput({ duration: '11s', platformAvailability: 'selectable' }));
+      expect(result.state).toBe('allowed');
       expect(result.canSubmit).toBe(true);
-      expect(result.issues.some(i => i.code === 'membership_risk')).toBe(true);
     });
   });
 
@@ -272,16 +278,16 @@ describe('evaluateVideoCapability', () => {
     it('15s + seedance-2.0-fast 返回建议配置', () => {
       const suggestion = suggestCompatibleVideoConfig('seedance-2.0-fast', '15s');
       expect(suggestion).toBeDefined();
-      expect(suggestion!.model).toBe('seedance-2.0');
+      expect(suggestion!.model).toBe('seedance-2.0-fast');
       expect(suggestion!.duration).toBe('10s');
-      expect(suggestion!.reason).toContain('会员权益限制');
+      expect(suggestion!.reason).toContain('实时能力证据');
     });
 
     it('15s + 其他模型返回建议配置', () => {
       const suggestion = suggestCompatibleVideoConfig('seedance-2.0', '15s');
       expect(suggestion).toBeDefined();
       expect(suggestion!.duration).toBe('10s');
-      expect(suggestion!.reason).toContain('15 秒时长');
+      expect(suggestion!.reason).toContain('实时能力证据');
     });
 
     it('非 15s 配置不返回建议', () => {
@@ -305,9 +311,8 @@ describe('evaluateVideoCapability', () => {
     });
   });
 
-  // ---- 测试 8: 15s 补丁开启不改变平台会员限制的判断 ----
-  describe('15s 补丁不影响会员限制判断', () => {
-    it('manual15sEnabled = true 时 15s + Fast 仍返回 unknown（不声称一定不可用）', () => {
+  describe('旧补丁标记不能绕过会员门禁', () => {
+    it('manual15sEnabled = true 时 15s 仍 blocked', () => {
       const input = makeBaseInput({
         model: 'seedance-2.0-fast',
         duration: '15s',
@@ -318,11 +323,11 @@ describe('evaluateVideoCapability', () => {
         accountStatus: healthyAccountStatus,
       });
       const result = evaluateVideoCapability(input);
-      expect(result.state).toBe('unknown');
-      expect(result.canSubmit).toBe(true);
+      expect(result.state).toBe('blocked');
+      expect(result.canSubmit).toBe(false);
     });
 
-    it('manual15sEnabled = false 时 15s + Fast 也返回 unknown', () => {
+    it('manual15sEnabled = false 时 15s 也 blocked', () => {
       const input = makeBaseInput({
         model: 'seedance-2.0-fast',
         duration: '15s',
@@ -333,8 +338,8 @@ describe('evaluateVideoCapability', () => {
         accountStatus: healthyAccountStatus,
       });
       const result = evaluateVideoCapability(input);
-      expect(result.state).toBe('unknown');
-      expect(result.canSubmit).toBe(true);
+      expect(result.state).toBe('blocked');
+      expect(result.canSubmit).toBe(false);
     });
 
     it('manual15sEnabled = true 时额度耗尽仍返回 blocked', () => {
@@ -426,5 +431,76 @@ describe('evaluateVideoCapability', () => {
       const result = evaluateVideoCapability(input);
       expect(result.state).not.toBe('blocked');
     });
+  });
+});
+
+describe('豆包新 UI 只读能力快照与 dry-run', () => {
+  const pageText = [
+    '快速 视频生成 图像生成 PPT 写作 翻译 深入研究 录音转写 更多',
+    'Seedance 2.5 Seedance 2.0 Seedance 2.0 Fast Seedance 2.0 Mini',
+    'Seedream 5.0 Pro Seedream 5.0 Lite Seedream 4.5 Seedream 4.0',
+    '4秒 5秒 10秒 11秒 15秒 3:4 4:3 9:16 16:9 1:1 21:9 2:3 3:2',
+  ].join(' ');
+
+  it('记录时间、账户层级、页面来源和适配器版本', () => {
+    const snapshot = buildDoubaoCapabilitySnapshot({
+      pageUrl: 'https://www.doubao.com/chat/create-video/',
+      bodyText: pageText,
+      observedAt: '2026-07-31T10:00:00.000Z',
+      accountTier: '免费',
+    });
+    expect(snapshot.observed_at).toBe('2026-07-31T10:00:00.000Z');
+    expect(snapshot.account_tier).toBe('免费');
+    expect(snapshot.source.kind).toBe('page');
+    expect(snapshot.adapter_version).toMatch(/^2\./);
+  });
+
+  it('从页面文字识别新模型、入口、比例和 4–15 秒范围', () => {
+    const snapshot = buildDoubaoCapabilitySnapshot({ pageUrl: 'https://www.doubao.com/', bodyText: pageText });
+    expect(snapshot.entries).toContain('视频生成');
+    expect(snapshot.video.models).toContain('Seedance 2.5');
+    expect(snapshot.image.models).toContain('Seedream 5.0 Pro');
+    expect(snapshot.video.durations).toEqual([4, 5, 10, 11, 15]);
+    expect(snapshot.image.aspect_ratios).toContain('2:3');
+  });
+
+  it('元素缺失时返回 unknown，不猜测能力', () => {
+    const snapshot = buildDoubaoCapabilitySnapshot({ pageUrl: 'https://www.doubao.com/', bodyText: '' });
+    expect(snapshot.status).toBe('unknown');
+    expect(snapshot.video.models).toEqual([]);
+    expect(snapshot.account_tier).toBe('unknown');
+  });
+
+  it('会员窗口记录为 action_required，dry-run 返回 membership_required', () => {
+    const snapshot = buildDoubaoCapabilitySnapshot({
+      pageUrl: 'https://www.doubao.com/',
+      bodyText: pageText,
+      membershipDialogText: '升级会员后可使用更长视频',
+    });
+    expect(snapshot.membership.availability).toBe('action_required');
+    expect(evaluateDryRunSelection(snapshot, { model: 'Seedance 2.5', duration: 11, aspectRatio: '16:9' }))
+      .toEqual({ ok: false, code: 'membership_required', finalSubmit: false });
+  });
+
+  it.each([
+    ['unknown', false, 'membership_required'],
+    ['selectable', true, 'ready'],
+  ] as const)('11 秒 availability=%s 时按实时证据门禁', (availability, ok, code) => {
+    const snapshot = buildDoubaoCapabilitySnapshot({ pageUrl: 'https://www.doubao.com/', bodyText: pageText });
+    snapshot.membership.availability = availability;
+    expect(evaluateDryRunSelection(snapshot, { model: 'Seedance 2.5', duration: 11, aspectRatio: '16:9' }))
+      .toEqual({ ok, code, finalSubmit: false });
+  });
+
+  it('dry-run 只验证可见配置，永不提交最终生成', () => {
+    const snapshot = buildDoubaoCapabilitySnapshot({ pageUrl: 'https://www.doubao.com/', bodyText: pageText });
+    expect(evaluateDryRunSelection(snapshot, { model: 'Seedance 2.5', duration: 10, aspectRatio: '16:9' }))
+      .toEqual({ ok: true, code: 'ready', finalSubmit: false });
+  });
+
+  it('历史 15 秒请求改写入口固定拒绝启用', async () => {
+    const forbiddenWebview = new Proxy({}, { get: () => { throw new Error('不得访问 webview'); } });
+    expect(await inject15sVideoPatch(forbiddenWebview as never)).toBe(false);
+    expect(await set15sVideoPatchEnabled(forbiddenWebview as never, true)).toBe(false);
   });
 });


### PR DESCRIPTION
## 背景

豆包当前页面的主入口、视频/图片模型、比例、时长与会员限制界面已发生变化。原实现依赖旧 UI，并包含 15 秒请求改写能力，无法安全适配当前页面。

## 变更

- 新增只读 UI 能力快照，记录 `observed_at`、账户层级、页面来源、适配器版本和 observed/partial/unknown 状态。
- 识别当前页面中的新入口、Seedance/Seedream 模型、4–15 秒时长、视频/图片比例和会员动作提示。
- 更新 Provider Adapter、自检、任务 UI、共享类型、CSV 校验和持久化归一化。
- 默认视频时长由 15 秒调整为 10 秒，不将截图价格、倍率或权益硬编码为永久规则。
- 11–15 秒仅在页面实时明确标记为 `selectable` 时可继续；`unknown` 与 `action_required` 均 fail-closed 为 `membership_required`。
- 移除 BrowserPanel 中手动 15 秒开关及生产请求改写调用；历史入口固定拒绝启用。
- dry-run/self-check 固定不点击最终生成、购买或升级控件。

## 验证

- R1 专项测试：46/46 通过。
- 相关回归：224/224 通过。
- 候选完整验证：487/487 通过。
- TypeScript、工程结构检查、contracts 边界和生产构建通过。
- 全局 ESLint：0 error，145 warning，低于仓库冻结上限 149。
- `git diff --check` 通过。

## 安全与交付状态

- 未真实生成视频或图片，未消耗额度。
- 未购买会员、未点击支付或升级、未绕过会员限制。
- 未读取或提交 Cookie、Token、签名、`.env`、支付信息或账号隐私。
- 未接入 Alice Agent，未修改 ERP、Discord Workspace 或其他项目。
- 未部署、未发布。

## 未纳入 PR 的本地现场

以下本地文件不属于本 PR，未被提交或推送：

- `AGENTS.md`
- `GLM_NEXT_TASK.md`
- `ROADMAP.md`
- `docs/handoffs/2026-07-31-doubao-ui-capability-refresh-priority.md`

本 PR 当前仅为 Draft；不代表 Ready、合并、部署或发布。