### PR TITLE
fix(doubao): fail closed on unavailable watermark removal

### DIFF
--- a/docs/handoffs/2026-08-13-doubao-watermark-hotfix-01.md
+++ b/docs/handoffs/2026-08-13-doubao-watermark-hotfix-01.md
@@ -1,0 +1,53 @@
+# DOUBAO-WATERMARK-HOTFIX-01 交接报告
+
+## 治理与冻结验收包
+
+已读取总架构师治理规则、项目 `AGENTS.md`、项目路线与最新豆包交接文档。
+
+- P0-1：复现去水印失败并定位链路
+- P0-2：只接受豆包平台明确证明的无水印地址
+- P0-3：热更新后以真实历史视频复验
+
+未生成新内容、未购买会员、未消耗额度、未使用第三方去水印服务、未裁剪或覆盖水印、未读取或输出凭据。
+
+## 根因
+
+1. 新播放器不再渲染 `<video>`，`vid` 位于视频卡片 React Fiber 的 `video` props，旧 DOM 扫描无法稳定取得。
+2. `/samantha/media/get_play_info` 的 `original_media_info` 是源媒体信息，不代表无水印。旧实现把它标记为无水印，导致下载成功但画面仍出现“豆包AI生成”。
+3. 豆包网页当前权威接口是 `POST /creativity/resource/get_without_watermark`。只有业务成功、`without_watermark=true` 且 `download_video[vid].download_url` 有效时，才可确认官方无水印下载可用。
+
+## 修复
+
+- 从最多 20 个当前视频卡片、最多 12 层 React Fiber 中只读提取 `vid`、`creation_task_id`、`message_id`。
+- 手动去水印入口强制 `requireWithoutWatermark=true`。
+- 新增官方无水印接口请求；只接受明确的 `without_watermark=true`。
+- `without_watermark=false` 时 fail-closed，不回退 `play_info`、SSE 缓存、DOM 或查询参数改写。
+- `play_info.original_media_info`、缓存 `original_media_info/download_url` 及页面结构化字段均不再视为无水印授权。
+- 下载 URL 保持平台原值，删除 `lr=video_gen_no_watermark` 参数伪装。
+- UI 明确说明只下载豆包官方开放的无水印视频。
+
+## 自动化门禁
+
+- 媒体专项：113 pass / 0 fail
+- 独立候选全量：491 pass / 0 fail（15 files）
+- TypeScript：通过
+- 工程结构与 contracts 边界：通过
+- Build：通过
+- 修改文件 ESLint：0 error（既有 warnings 未扩项清理）
+- `git diff --check`：通过
+
+## 真实历史视频复验
+
+- 会话：`https://www.doubao.com/chat/38437390431449858`
+- 页面 vid：成功识别
+- 官方响应：HTTP 200、业务 code 0、`without_watermark=false`
+- UI：显示“豆包官方未向当前账号或该视频开放无水印下载”
+- 下载目录：无新增文件
+- Seedance 预计额度：10 → 10，未记账
+- 未发送生成、未点击套餐、未购买会员
+
+## 裁决
+
+热修 PASS：旧的“带水印视频被误报为去水印成功”已修复。当前账号/历史视频无法得到无水印文件，是豆包官方明确关闭该能力，不是本地下载故障；应用现已正确拒绝并说明原因。
+
+失败证据 `watermar_1.mp4` 保留在用户下载目录，未擅自删除。三张本任务抽帧仍位于未跟踪目录 `.codex-watermark-check/`，不会进入候选提交。本报告随单一候选提交交付；未推送。

--- a/src/components/BrowserPanel.tsx
+++ b/src/components/BrowserPanel.tsx
@@ -113,9 +113,8 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
         lower.includes('lr=');
       if (isImageOnly && !isLikelyVideo) continue;
       if (!isLikelyVideo) continue;
-      const clean = trimmed.includes('lr=')
-        ? trimmed.replace(/lr=[^&]+/g, 'lr=video_gen_no_watermark')
-        : trimmed;
+      // 下载豆包明确返回的原始 URL；禁止通过改写查询参数伪装成无水印地址。
+      const clean = trimmed;
       if (!seen.has(clean)) {
         seen.add(clean);
         result.push(clean);
@@ -342,7 +341,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
     }
 
     setManualVideoExtracting(true);
-    useTaskStore.getState().setAccountAutomationState(accountId, 'generating', '正在提取当前对话的视频地址...');
+    useTaskStore.getState().setAccountAutomationState(accountId, 'generating', '正在查询豆包官方无水印下载...');
     try {
       const result = await manualResolveVideoArtifact(webview, {
         conversationUrl: webview.getURL(),
@@ -433,7 +432,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
 
       try {
         useAccountStore.getState().selectAccount(accountId);
-        useTaskStore.getState().setAccountAutomationState(accountId, 'generating', '手动提取视频地址...');
+        useTaskStore.getState().setAccountAutomationState(accountId, 'generating', '正在查询豆包官方无水印下载...');
         const conversationUrl = task.runtime?.conversationUrl;
         if (conversationUrl && webview.getURL() !== conversationUrl) {
           message.info('正在打开该任务对应的豆包对话...');
@@ -963,10 +962,10 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
         <div className="browser-url-bar">
           <span className="browser-url-text">doubao.com</span>
         </div>
-        <Tooltip title="提取并下载当前对话视频，同时更新额度预测">
+        <Tooltip title="仅在豆包官方明确开放无水印下载时提取；不可用时不会下载替代视频">
           <button
             onClick={() => void handleExtractCurrentVideo()}
-            title="提取当前对话视频"
+            title="提取官方无水印视频"
             disabled={manualVideoExtracting || !!accountBusy[activeAccount.id]}
             style={{
               width: 30,

--- a/src/utils/doubaoBridge.ts
+++ b/src/utils/doubaoBridge.ts
@@ -4125,7 +4125,6 @@ import type{
 } from './videoArtifactResolver';
 import {
   parsePlayInfoResponse,
-  parseDownloadInfoResponse,
   parseConversationScanData,
   sortCandidatesByTrust,
   filterCandidatesByContext,
@@ -4149,6 +4148,8 @@ export interface ResolveVideoArtifactContext {
   timeoutMs?: number;
   /** 是否为手动提取（影响重试次数和日志） */
   isManual?: boolean;
+  /** 仅接受豆包官方明确确认的无水印下载地址 */
+  requireWithoutWatermark?: boolean;
   /** 可选的中断信号，取消后立即停止解析 */
   signal?: AbortSignal;
 }
@@ -4332,14 +4333,41 @@ async function executeDownloadInfoStrategy(
   signal: AbortSignal | undefined,
 ): Promise<{ candidate?: VideoCandidate; attempt: ArtifactAttempt; succeeded: boolean }> {
   try {
-    const downloadResult = await fetchCreationDownloadInfo(webview, vid, timeoutMs, signal);
+    const downloadResult = await fetchWithoutWatermarkInfo(webview, vid, timeoutMs, signal);
     if (downloadResult) {
-      const candidate = parseDownloadInfoResponse(downloadResult.data);
-      if (candidate) {
+      const response = downloadResult.data as {
+        code?: unknown;
+        data?: {
+          without_watermark?: unknown;
+          download_video?: Record<string, { download_url?: unknown }>;
+        };
+      } | null;
+      const downloadUrl = response?.data?.download_video?.[vid]?.download_url;
+      if (
+        downloadResult.status === 200
+        && response?.code === 0
+        && response?.data?.without_watermark === true
+        && isValidVideoUrl(downloadUrl)
+      ) {
         return {
-          candidate: { ...candidate, vid },
+          candidate: {
+            url: downloadUrl,
+            source: 'platform_download_info',
+            isOriginal: true,
+            vid,
+          },
           attempt: { strategy: 'platform_download_info', result: 'success' },
           succeeded: true,
+        };
+      }
+      if (downloadResult.status === 200 && response?.code === 0 && response?.data?.without_watermark === false) {
+        return {
+          attempt: {
+            strategy: 'platform_download_info',
+            result: 'fail',
+            reason: '豆包官方未向当前账号或该视频开放无水印下载（without_watermark=false）',
+          },
+          succeeded: false,
         };
       }
       const status = classifyVideoResolutionError(downloadResult.status, downloadResult.data);
@@ -4382,8 +4410,8 @@ async function retryApiStrategiesAfterScan(
   attempts.push(piResult.attempt);
   if (piResult.succeeded) succeeded = true;
 
-  // 4b-2: 重试创作空间下载信息接口
-  if (!isAborted() && !succeeded) {
+  // 4b-2: 无论普通播放地址是否存在，都必须查询官方无水印能力。
+  if (!isAborted()) {
     const dlResult = await executeDownloadInfoStrategy(webview, vid, remainingMs(), signal);
     if (dlResult.candidate) candidates.push(dlResult.candidate);
     attempts.push(dlResult.attempt);
@@ -4424,8 +4452,7 @@ async function tryPageFallbackStrategy(
 /**
  * 策略 1: 从已拦截的 SSE 响应缓存中提取视频地址。
  * 根据 fieldSource 判定是否为原始地址：
- * - original_media_info / download_url → isOriginal: true
- * - play_info / 未知 → isOriginal: false
+ * 缓存来自普通播放/SSE 链，不能证明平台已开放无水印下载。
  */
 async function tryCapturedResponseStrategy(
   webview: WebviewHandle,
@@ -4436,10 +4463,9 @@ async function tryCapturedResponseStrategy(
       return { attempt: { strategy: 'captured_response', result: 'skip', reason: '无缓存' } };
     }
     if (cache.videoUrl && isValidVideoUrl(cache.videoUrl)) {
-      const isOriginal = cache.fieldSource === 'original_media_info' || cache.fieldSource === 'download_url';
       return {
         vid: cache.vid,
-        candidate: { url: cache.videoUrl, source: 'captured_response', vid: cache.vid, isOriginal },
+        candidate: { url: cache.videoUrl, source: 'captured_response', vid: cache.vid, isOriginal: false },
         attempt: { strategy: 'captured_response', result: 'success', reason: `fieldSource=${cache.fieldSource || 'unknown'}` },
       };
     }
@@ -4463,7 +4489,12 @@ function selectBestCandidate(
     conversationUrl: ctx.conversationUrl,
     runId: ctx.runId,
   };
-  const filtered = filterCandidatesByContext(candidates, filterCtx);
+  const contextMatched = filterCandidatesByContext(candidates, filterCtx);
+  const filtered = ctx.requireWithoutWatermark
+    ? contextMatched.filter((candidate) => (
+      candidate.source === 'platform_download_info' && candidate.isOriginal
+    ))
+    : contextMatched;
   const sorted = sortCandidatesByTrust(filtered);
 
   // 如果有多个原始地址候选且无法唯一匹配，标记需要人工选择
@@ -4482,7 +4513,7 @@ function selectBestCandidate(
   }
 
   // 过滤后有候选被排除且提供了 conversationUrl → 无法可靠归属
-  if (candidates.length > 0 && filtered.length === 0 && ctx.conversationUrl) {
+  if (!ctx.requireWithoutWatermark && candidates.length > 0 && filtered.length === 0 && ctx.conversationUrl) {
     return createFailedResolution(
       'needs_manual_selection',
       '存在候选但无法可靠匹配到当前会话，需人工确认',
@@ -4492,7 +4523,14 @@ function selectBestCandidate(
   }
 
   // ---- 判断最终失败原因 ----
-  const lastError = attempts.filter((a) => a.result === 'fail').pop();
+  const officialWatermarkError = ctx.requireWithoutWatermark
+    ? attempts.find((attempt) => (
+      attempt.strategy === 'platform_download_info'
+      && attempt.result === 'fail'
+      && attempt.reason?.includes('without_watermark=false')
+    ))
+    : undefined;
+  const lastError = officialWatermarkError ?? attempts.filter((a) => a.result === 'fail').pop();
   const reason = lastError?.reason || '所有策略均未获取到视频地址';
   return createFailedResolution('unavailable', reason, attempts, resolvedVid);
 }
@@ -4574,133 +4612,31 @@ async function fetchPlayInfoRaw(
 }
 
 /**
- * 创作空间三步下载信息解析：
- * 1. 获取创作空间列表（aispace/get_creation_list）
- * 2. 在列表中查找 vid 匹配的创作节点，提取 resource_id
- * 3. 用 resource_id 调用 aispace/get_download_info 获取无水印下载地址
- *
- * 超时预算在两步之间拆分（40% / 60%），每步使用页内 AbortController
- * 确保超时后 fetch 被真正中止，不会泄漏到下一策略。
+ * 调用豆包网页当前使用的官方无水印能力接口。
+ * 上层仅在响应明确给出 without_watermark=true 时接受下载地址。
  */
-async function fetchCreationDownloadInfo(
+async function fetchWithoutWatermarkInfo(
   webview: WebviewHandle,
   vid: string,
   timeoutMs: number,
   signal?: AbortSignal,
 ): Promise<PlayInfoRawResult | null> {
-  // 拆分预算：第一步 40%，第二步 60%（至少各 1 秒）
-  const listTimeout = Math.max(1000, Math.floor(timeoutMs * 0.4));
-  const dlTimeout = Math.max(1000, timeoutMs - listTimeout);
-
-  // ---- Step 1+2: 获取创作列表并查找匹配 vid 的节点 ----
   if (signal?.aborted) return null;
-  const nodeCode = `
+  const code = `
     (function() {
       var vid = ${JSON.stringify(vid)};
-      var timeoutMs = ${listTimeout};
-      var uuid = crypto.randomUUID ? crypto.randomUUID() : Date.now().toString();
-      var deviceId = (function() {
-        var stored = sessionStorage.getItem('__ds_device_id');
-        if (stored) return stored;
-        var id = String(Date.now()) + String(Math.floor(Math.random() * 1000000));
-        sessionStorage.setItem('__ds_device_id', id);
-        return id;
-      })();
-      var params = 'version_code=20800&language=zh&device_platform=web&aid=497858&real_aid=497858&pkg_type=release_version&device_id=' + deviceId + '&pc_version=3.20.2&web_id=&tea_uuid=&region=CN&sys_region=CN&samantha_web=1&web_platform=browser&use-olympus-account=1&web_tab_id=' + uuid;
-      var url = '/samantha/aispace/get_creation_list?' + params;
+      var timeoutMs = ${timeoutMs};
       var controller = new AbortController();
       var timeoutId = setTimeout(function() { controller.abort(); }, timeoutMs);
-      return fetch(url, {
+      return fetch('/creativity/resource/get_without_watermark', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'agw-js-conv': 'str',
           'origin': location.origin,
           'referer': location.href,
         },
         credentials: 'include',
-        body: JSON.stringify({ cursor: '', count: 50, type: 'video' }),
-        signal: controller.signal,
-      }).then(function(r) {
-        return r.text().then(function(text) {
-          var data = null;
-          try { data = JSON.parse(text); } catch(e) {}
-          // 在列表中查找 vid 匹配的创作节点
-          var resourceId = null;
-          if (data && data.data) {
-            var items = data.data.creation_list || data.data.items || data.data.list || [];
-            if (Array.isArray(items)) {
-              for (var i = 0; i < items.length; i++) {
-                var item = items[i];
-                if (!item || typeof item !== 'object') continue;
-                // 匹配 vid（可能在 item.vid / item.video_id / item.resource.vid 等位置）
-                var itemVid = item.vid || item.video_id || item.videoId ||
-                  (item.resource && (item.resource.vid || item.resource.video_id)) || '';
-                if (itemVid === vid) {
-                  resourceId = item.resource_id || item.node_id || item.id ||
-                    (item.resource && (item.resource.resource_id || item.resource.id)) || null;
-                  break;
-                }
-              }
-            }
-          }
-          return { found: !!resourceId, resourceId: resourceId, status: r.status };
-        });
-      }).catch(function(e) {
-        return { found: false, resourceId: null, status: 0, error: e.message };
-      }).finally(function() {
-        clearTimeout(timeoutId);
-      });
-    })();
-  `;
-
-  let resourceId: string | null = null;
-  try {
-    const nodeResult = await raceWithAbort(
-      safeExecuteJS<{ found: boolean; resourceId: string | null; status: number; error?: string }>(
-        webview, nodeCode, listTimeout, 'fetchCreationList'
-      ),
-      signal,
-      null,
-    );
-    if (!nodeResult || !nodeResult.found || !nodeResult.resourceId) {
-      return null;
-    }
-    resourceId = nodeResult.resourceId;
-  } catch {
-    return null;
-  }
-
-  // 两步之间检查取消信号
-  if (signal?.aborted) return null;
-
-  // ---- Step 3: 用 resource_id 调用 aispace/get_download_info ----
-  const dlCode = `
-    (function() {
-      var resourceId = ${JSON.stringify(resourceId)};
-      var timeoutMs = ${dlTimeout};
-      var uuid = crypto.randomUUID ? crypto.randomUUID() : Date.now().toString();
-      var deviceId = (function() {
-        var stored = sessionStorage.getItem('__ds_device_id');
-        if (stored) return stored;
-        var id = String(Date.now()) + String(Math.floor(Math.random() * 1000000));
-        sessionStorage.setItem('__ds_device_id', id);
-        return id;
-      })();
-      var params = 'version_code=20800&language=zh&device_platform=web&aid=497858&real_aid=497858&pkg_type=release_version&device_id=' + deviceId + '&pc_version=3.20.2&web_id=&tea_uuid=&region=CN&sys_region=CN&samantha_web=1&web_platform=browser&use-olympus-account=1&web_tab_id=' + uuid;
-      var url = '/samantha/aispace/get_download_info?' + params;
-      var controller = new AbortController();
-      var timeoutId = setTimeout(function() { controller.abort(); }, timeoutMs);
-      return fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'agw-js-conv': 'str',
-          'origin': location.origin,
-          'referer': location.href,
-        },
-        credentials: 'include',
-        body: JSON.stringify({ resource_id: resourceId }),
+        body: JSON.stringify({ vid: [vid] }),
         signal: controller.signal,
       }).then(function(r) {
         return r.text().then(function(text) {
@@ -4719,18 +4655,18 @@ async function fetchCreationDownloadInfo(
   try {
     const result = await raceWithAbort(
       safeExecuteJS<{ status: number; data: unknown; error?: string }>(
-        webview, dlCode, dlTimeout, 'fetchAispaceDownloadInfo'
+        webview, code, timeoutMs, 'fetchWithoutWatermarkInfo'
       ),
       signal,
       null,
     );
-    if (result && result.status > 0) {
-      return { status: result.status, data: result.data };
-    }
-    return null;
+    return result && result.status > 0
+      ? { status: result.status, data: result.data }
+      : null;
   } catch {
     return null;
   }
+
 }
 
 /**
@@ -4803,6 +4739,45 @@ async function scanConversationStructured(
           if (scripts[s].textContent) results.push(JSON.parse(scripts[s].textContent));
         } catch(e) {}
       }
+      // 4. 当前豆包播放器不再渲染 <video>，而是把 vid 保存在
+      // React 组件的 video props 中。这里只读取当前已挂载的视频卡片，
+      // 不读取 Cookie/Token，也不直接使用带水印封面 URL。
+      var videoBlocks = document.querySelectorAll('[class*="block-video"]');
+      for (var v = 0; v < videoBlocks.length && v < 20; v++) {
+        try {
+          var node = videoBlocks[v];
+          var propertyNames = Object.getOwnPropertyNames(node);
+          var fiberKey = '';
+          for (var p = 0; p < propertyNames.length; p++) {
+            if (propertyNames[p].indexOf('__reactFiber$') === 0) {
+              fiberKey = propertyNames[p];
+              break;
+            }
+          }
+          if (!fiberKey) continue;
+          var fiber = node[fiberKey];
+          var videoData = null;
+          for (var depth = 0; fiber && depth < 12; depth++) {
+            var pendingVideo = fiber.pendingProps && fiber.pendingProps.video;
+            var memoizedVideo = fiber.memoizedProps && fiber.memoizedProps.video;
+            var candidateVideo = pendingVideo || memoizedVideo;
+            if (candidateVideo && typeof candidateVideo.vid === 'string' && candidateVideo.vid.trim()) {
+              videoData = {
+                vid: candidateVideo.vid.trim(),
+                creation_task_id: typeof candidateVideo.creation_task_id === 'string'
+                  ? candidateVideo.creation_task_id
+                  : undefined,
+                message_id: typeof candidateVideo.messageId === 'string'
+                  ? candidateVideo.messageId
+                  : undefined
+              };
+              break;
+            }
+            fiber = fiber.return;
+          }
+          if (videoData) results.push({ video: videoData });
+        } catch(e) {}
+      }
       return results;
     })();
   `;
@@ -4839,6 +4814,7 @@ export async function manualResolveVideoArtifact(
   return resolveVideoArtifact(webview, {
     ...ctx,
     isManual: true,
+    requireWithoutWatermark: true,
     timeoutMs,
   });
 }

--- a/src/utils/videoArtifactResolver.ts
+++ b/src/utils/videoArtifactResolver.ts
@@ -55,7 +55,7 @@ export interface VideoCandidate {
 
 /**
  * 从 get_play_info 接口响应中提取视频地址。
- * 优先使用 original_media_info，其次 download_url / no_watermark_url，最后 play_info。
+ * 解析普通播放媒体。该接口中的字段不能证明平台已开放无水印下载。
  */
 export function parsePlayInfoResponse(raw: unknown): VideoCandidate | null {
   if (!raw || typeof raw !== 'object') return null;
@@ -69,18 +69,18 @@ export function parsePlayInfoResponse(raw: unknown): VideoCandidate | null {
     const om = originalMedia as Record<string, unknown>;
     const url = extractUrlFromFields(om, ['main_url', 'main', 'url', 'download_url']);
     if (url) {
-      return { url, source: 'play_info', isOriginal: true };
+      return { url, source: 'play_info', isOriginal: false };
     }
   }
 
   // 2. download_url
   if (typeof obj.download_url === 'string' && isValidVideoUrl(obj.download_url)) {
-    return { url: obj.download_url, source: 'play_info', isOriginal: true };
+    return { url: obj.download_url, source: 'play_info', isOriginal: false };
   }
 
   // 3. no_watermark_url
   if (typeof obj.no_watermark_url === 'string' && isValidVideoUrl(obj.no_watermark_url)) {
-    return { url: obj.no_watermark_url, source: 'play_info', isOriginal: true };
+    return { url: obj.no_watermark_url, source: 'play_info', isOriginal: false };
   }
 
   // 4. play_info.main
@@ -180,12 +180,12 @@ export function parseCapturedResponse(raw: unknown): VideoCandidate | null {
   if (!raw || typeof raw !== 'object') return null;
   const obj = raw as Record<string, unknown>;
 
-  // 优先找 original_media_info
+  // original_media_info 仅表示源媒体，不能证明无水印权限
   const originalMedia = obj.original_media_info;
   if (originalMedia && typeof originalMedia === 'object') {
     const url = extractUrlFromFields(originalMedia as Record<string, unknown>, ['main_url', 'main', 'url']);
     if (url) {
-      return { url, source: 'captured_response', isOriginal: true, vid: findVidDeep(obj, 0) };
+      return { url, source: 'captured_response', isOriginal: false, vid: findVidDeep(obj, 0) };
     }
   }
 
@@ -201,7 +201,7 @@ export function parseCapturedResponse(raw: unknown): VideoCandidate | null {
 
   // 直接的 download_url
   if (typeof obj.download_url === 'string' && isValidVideoUrl(obj.download_url)) {
-    return { url: obj.download_url, source: 'captured_response', isOriginal: true, vid: findVidDeep(obj, 0) };
+    return { url: obj.download_url, source: 'captured_response', isOriginal: false, vid: findVidDeep(obj, 0) };
   }
 
   return null;
@@ -233,30 +233,30 @@ export function parseConversationScanData(raw: unknown): ConversationScanResult 
   const vid = findVidDeep(obj, 0);
   const foundUrls = new Set<string>();
 
-  // 1. 从 original_media_info 对象内部提取 URL（保证同一对象 → isOriginal: true）
+  // 1. original_media_info 仅代表源媒体，不代表无水印授权
   const originalUrls = collectUrlsFromKey(obj, 'original_media_info');
   for (const url of originalUrls) {
     if (!foundUrls.has(url)) {
       foundUrls.add(url);
-      candidates.push({ url, source: 'conversation_scan', vid, isOriginal: true });
+      candidates.push({ url, source: 'conversation_scan', vid, isOriginal: false });
     }
   }
 
-  // 2. 从 download_url 字段提取（字段本身就是 URL → isOriginal: true）
+  // 2. 普通结构化 download_url 也不能证明无水印授权
   const downloadUrls = collectUrlsFromKey(obj, 'download_url');
   for (const url of downloadUrls) {
     if (!foundUrls.has(url)) {
       foundUrls.add(url);
-      candidates.push({ url, source: 'conversation_scan', vid, isOriginal: true });
+      candidates.push({ url, source: 'conversation_scan', vid, isOriginal: false });
     }
   }
 
-  // 3. 从 no_watermark_url 字段提取（明确无水印 → isOriginal: true）
+  // 3. 页面结构化字段不是当前权威能力接口，仍保守标记
   const noWmUrls = collectUrlsFromKey(obj, 'no_watermark_url');
   for (const url of noWmUrls) {
     if (!foundUrls.has(url)) {
       foundUrls.add(url);
-      candidates.push({ url, source: 'conversation_scan', vid, isOriginal: true });
+      candidates.push({ url, source: 'conversation_scan', vid, isOriginal: false });
     }
   }
 

--- a/tests/unit/videoArtifactIntegration.test.ts
+++ b/tests/unit/videoArtifactIntegration.test.ts
@@ -23,6 +23,7 @@ import type { WebviewHandle } from '../../src/utils/doubaoBridge';
 function createMockWebview(responses: {
   cache?: { found: boolean; vid?: string; videoUrl?: string; fieldSource?: string } | null;
   playInfo?: { status: number; data: unknown } | null;
+  withoutWatermark?: { status: number; data: unknown } | null;
   creationList?: { found: boolean; resourceId: string | null; status: number } | null;
   downloadInfo?: { status: number; data: unknown } | null;
   structuredData?: unknown[] | null;
@@ -49,6 +50,11 @@ function createMockWebview(responses: {
       if (code.includes('get_play_info')) {
         if (responses.playInfo === null) return { status: 0, data: null, error: 'timeout' };
         return responses.playInfo;
+      }
+
+      if (code.includes('get_without_watermark')) {
+        if (responses.withoutWatermark === null) return { status: 0, data: null, error: 'timeout' };
+        return responses.withoutWatermark;
       }
 
       // fetchCreationDownloadInfo step 1 — 检测 get_creation_list
@@ -317,9 +323,9 @@ describe('resolveVideoArtifact 集成测试', () => {
     expect(webview.executeJavaScript).not.toHaveBeenCalled();
   });
 
-  // ---- 7. 创作空间三步解析 ----
+  // ---- 7. 官方无水印能力解析 ----
 
-  it('创作空间三步解析成功时返回 download_infos 中的地址', async () => {
+  it('官方无水印接口明确开放时返回对应 vid 的下载地址', async () => {
     const webview = createMockWebview({
       cache: {
         found: true,
@@ -328,14 +334,15 @@ describe('resolveVideoArtifact 集成测试', () => {
         fieldSource: '',
       },
       playInfo: { status: 200, data: { data: {} } }, // play_info 无有效 URL
-      creationList: { found: true, resourceId: 'res_001', status: 200 },
-      downloadInfo: {
+      withoutWatermark: {
         status: 200,
         data: {
+          code: 0,
           data: {
-            download_infos: [
-              { main_url: 'https://vod.example.com/video/aispace_no_wm.mp4' },
-            ],
+            without_watermark: true,
+            download_video: {
+              vid_aispace_001: { download_url: 'https://vod.example.com/video/aispace_no_wm.mp4' },
+            },
           },
         },
       },
@@ -431,19 +438,121 @@ describe('resolveVideoArtifact 集成测试', () => {
     expect(playInfoCalls.length).toBeGreaterThan(0);
   });
 
+  it('新播放器 React video props 中的 vid 会回补官方无水印接口', async () => {
+    const executeJavaScript = vi.fn(async (code: string): Promise<unknown> => {
+      if (code.includes('window.__doubaoVideoCache')) return { found: false };
+      if (code.includes('__reactFiber$')) {
+        return [{ video: { vid: 'vid_react_player_001', creation_task_id: 'task_001' } }];
+      }
+      if (code.includes('get_play_info')) {
+        return {
+          status: 200,
+          data: {
+            data: {
+              original_media_info: {
+                main_url: 'https://vod.example.com/video/react_player_original.mp4',
+              },
+            },
+          },
+        };
+      }
+      if (code.includes('get_without_watermark')) {
+        return {
+          status: 200,
+          data: {
+            code: 0,
+            data: {
+              without_watermark: true,
+              download_video: {
+                vid_react_player_001: {
+                  download_url: 'https://vod.example.com/video/react_player_without_watermark.mp4',
+                },
+              },
+            },
+          },
+        };
+      }
+      if (code.includes("querySelectorAll('video')")) return [];
+      if (code.includes('JSON.stringify(urls)')) return '[]';
+      return null;
+    });
+    const webview: WebviewHandle = {
+      executeJavaScript,
+      loadURL: vi.fn(),
+      getURL: vi.fn(() => 'https://www.doubao.com/chat/38437390431449858'),
+    };
+
+    const result = await manualResolveVideoArtifact(webview, {
+      conversationUrl: webview.getURL(),
+      timeoutMs: 5000,
+    });
+
+    expect(result).toMatchObject({
+      status: 'resolved',
+      source: 'platform_download_info',
+      vid: 'vid_react_player_001',
+      url: 'https://vod.example.com/video/react_player_without_watermark.mp4',
+    });
+    expect(executeJavaScript).toHaveBeenCalledWith(
+      expect.stringContaining('__reactFiber$'),
+    );
+  });
+
+  it('官方明确无水印不可用时手动入口不回退普通源媒体', async () => {
+    const webview = createMockWebview({
+      cache: {
+        found: true,
+        vid: 'vid_watermark_denied_001',
+        videoUrl: 'https://vod.example.com/video/captured_original.mp4',
+        fieldSource: 'original_media_info',
+      },
+      playInfo: {
+        status: 200,
+        data: {
+          data: {
+            original_media_info: {
+              main_url: 'https://vod.example.com/video/play_info_original.mp4',
+            },
+          },
+        },
+      },
+      withoutWatermark: {
+        status: 200,
+        data: { code: 0, data: { without_watermark: false } },
+      },
+      structuredData: [],
+      domUrls: [],
+      resultUrl: '[]',
+    });
+
+    const result = await manualResolveVideoArtifact(webview, {
+      conversationUrl: 'https://www.doubao.com/chat/denied',
+      timeoutMs: 5000,
+    });
+
+    expect(result.status).toBe('unavailable');
+    expect(result.url).toBeUndefined();
+    expect(result.reason).toContain('without_watermark=false');
+    expect(result.attempts).toContainEqual(expect.objectContaining({
+      strategy: 'platform_download_info',
+      result: 'fail',
+    }));
+  });
+
   it('扫描仅得到 vid 后回补 platform_download_info 成功解析', async () => {
     const webview = createMockWebview({
       cache: { found: false },
       // play_info 回补时返回空数据（无有效 URL）
       playInfo: { status: 200, data: { data: {} } },
-      creationList: { found: true, resourceId: 'res_retry_002', status: 200 },
-      downloadInfo: {
+      withoutWatermark: {
         status: 200,
         data: {
+          code: 0,
           data: {
-            download_infos: [
-              { main_url: 'https://vod.example.com/video/scan_vid_retry_dl.mp4' },
-            ],
+            without_watermark: true,
+            download_video: {
+              vid_scan_only_002: { download_url: 'https://vod.example.com/video/scan_vid_retry_dl.mp4' },
+            },
           },
         },
       },

--- a/tests/unit/videoArtifactResolver.test.ts
+++ b/tests/unit/videoArtifactResolver.test.ts
@@ -35,7 +35,7 @@ import type { VideoCandidate } from '../../src/utils/videoArtifactResolver';
 // ==================== parsePlayInfoResponse ====================
 
 describe('parsePlayInfoResponse', () => {
-  it('解析 original_media_info.main_url（原始地址）', () => {
+  it('解析 original_media_info.main_url（普通源媒体）', () => {
     const raw = {
       data: {
         original_media_info: {
@@ -47,10 +47,10 @@ describe('parsePlayInfoResponse', () => {
     expect(result).not.toBeNull();
     expect(result!.url).toBe('https://vod.example.com/video/original123.mp4');
     expect(result!.source).toBe('play_info');
-    expect(result!.isOriginal).toBe(true);
+    expect(result!.isOriginal).toBe(false);
   });
 
-  it('解析 original_media_info.main（原始地址）', () => {
+  it('解析 original_media_info.main（普通源媒体）', () => {
     const raw = {
       data: {
         original_media_info: {
@@ -61,10 +61,10 @@ describe('parsePlayInfoResponse', () => {
     const result = parsePlayInfoResponse(raw);
     expect(result).not.toBeNull();
     expect(result!.url).toBe('https://vod.example.com/video/main456.mp4');
-    expect(result!.isOriginal).toBe(true);
+    expect(result!.isOriginal).toBe(false);
   });
 
-  it('解析 download_url（原始地址）', () => {
+  it('解析 download_url（普通播放接口字段）', () => {
     const raw = {
       data: {
         download_url: 'https://vod.example.com/video/download789.mp4',
@@ -73,10 +73,10 @@ describe('parsePlayInfoResponse', () => {
     const result = parsePlayInfoResponse(raw);
     expect(result).not.toBeNull();
     expect(result!.url).toBe('https://vod.example.com/video/download789.mp4');
-    expect(result!.isOriginal).toBe(true);
+    expect(result!.isOriginal).toBe(false);
   });
 
-  it('解析 no_watermark_url（原始地址）', () => {
+  it('非权威接口中的 no_watermark_url 不视为已授权', () => {
     const raw = {
       data: {
         no_watermark_url: 'https://vod.example.com/video/nowm012.mp4',
@@ -84,7 +84,7 @@ describe('parsePlayInfoResponse', () => {
     };
     const result = parsePlayInfoResponse(raw);
     expect(result).not.toBeNull();
-    expect(result!.isOriginal).toBe(true);
+    expect(result!.isOriginal).toBe(false);
   });
 
   it('仅 play_info.main（非原始地址）', () => {
@@ -298,7 +298,7 @@ describe('parseCapturedResponse', () => {
     const result = parseCapturedResponse(raw);
     expect(result).not.toBeNull();
     expect(result!.url).toBe('https://vod.example.com/video/cap666.mp4');
-    expect(result!.isOriginal).toBe(true);
+    expect(result!.isOriginal).toBe(false);
     expect(result!.vid).toBe('v1234567890abcdef');
   });
 
@@ -319,7 +319,7 @@ describe('parseCapturedResponse', () => {
     };
     const result = parseCapturedResponse(raw);
     expect(result).not.toBeNull();
-    expect(result!.isOriginal).toBe(true);
+    expect(result!.isOriginal).toBe(false);
   });
 
   it('null 输入返回 null', () => {
@@ -368,7 +368,7 @@ describe('parseConversationScanData', () => {
 
   // ---- P1-5 回归：URL 与 original_media_info 必须同一对象 ----
 
-  it('P1-5: URL 与 original_media_info 属于同一对象时标记为原始', () => {
+  it('P1-5: original_media_info 同对象也不等于无水印授权', () => {
     const raw = {
       messages: [
         {
@@ -389,7 +389,7 @@ describe('parseConversationScanData', () => {
     const original = result.candidates.find(c => c.url.includes('orig_msg1'));
     const nonOriginal = result.candidates.find(c => c.url.includes('play_msg2'));
     expect(original).toBeDefined();
-    expect(original!.isOriginal).toBe(true);
+    expect(original!.isOriginal).toBe(false);
     expect(nonOriginal).toBeDefined();
     expect(nonOriginal!.isOriginal).toBe(false);
   });
@@ -415,7 +415,7 @@ describe('parseConversationScanData', () => {
     expect(playB!.isOriginal).toBe(false);
   });
 
-  it('P1-5: download_url 字段直接作为字符串时标记为原始', () => {
+  it('P1-5: 页面 download_url 字段不等于无水印授权', () => {
     const raw = {
       item: {
         vid: 'vid_dl_test',
@@ -425,10 +425,10 @@ describe('parseConversationScanData', () => {
     const result = parseConversationScanData(raw);
     const dl = result.candidates.find(c => c.url.includes('direct_dl'));
     expect(dl).toBeDefined();
-    expect(dl!.isOriginal).toBe(true);
+    expect(dl!.isOriginal).toBe(false);
   });
 
-  it('P1-5: no_watermark_url 字段标记为原始', () => {
+  it('P1-5: 页面 no_watermark_url 字段仍需权威接口确认', () => {
     const raw = {
       item: {
         vid: 'vid_nowm_test',
@@ -438,7 +438,7 @@ describe('parseConversationScanData', () => {
     const result = parseConversationScanData(raw);
     const nowm = result.candidates.find(c => c.url.includes('nowm'));
     expect(nowm).toBeDefined();
-    expect(nowm!.isOriginal).toBe(true);
+    expect(nowm!.isOriginal).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What changed

- Detect the current Doubao video `vid` from mounted React video-card props when no `<video>` element exists.
- Query Doubao's current official `/creativity/resource/get_without_watermark` endpoint.
- Accept a download only when the platform explicitly returns `without_watermark=true` and a valid URL for the same `vid`.
- Treat `play_info.original_media_info`, captured SSE URLs, and page URLs as ordinary media rather than proof of watermark removal.
- Remove query-parameter rewriting and explain fail-closed behavior in the UI.

## Root cause

The previous implementation interpreted `original_media_info` as a watermark-free asset. A real download proved that this URL still contains the visible “豆包AI生成” watermark. Doubao now exposes watermark availability separately through `get_without_watermark`.

## Verification

- Media resolver: 113/113 pass
- Full unit suite: 491/491 pass
- TypeScript checks: pass
- Project/contracts boundaries: pass
- Production build: pass
- Real historical conversation: platform returned `without_watermark=false`; UI refused fallback download, download count and Seedance estimate remained unchanged

## Safety

No generation, membership purchase, quota consumption, credential access, third-party removal service, cropping, overlay, or deployment.
