### PR TITLE
fix(doubao): handle duration membership gate

### DIFF
--- a/docs/handoffs/2026-08-13-doubao-ui-duration-membership-01.md
+++ b/docs/handoffs/2026-08-13-doubao-ui-duration-membership-01.md
@@ -34,6 +34,10 @@
 - 修改文件 ESLint：0 error（既有 warnings 未扩项清理）
 - `git diff --check`：通过
 
+### CI R1
+
+首轮 GitHub CI 仅因本包滑杆识别正则新增 5 个 `no-useless-escape` warnings，使全局 warning 数达到 150、超过上限 149。R1 将数字和空格匹配改为等价的字符类表达，不修改全局阈值、不清理无关旧债；等待新 HEAD CI 复验。
+
 ## 状态
 
 代码候选已实现并通过自动化门禁，等待总架构师复验。未部署。

--- a/docs/handoffs/2026-08-13-doubao-ui-duration-membership-01.md
+++ b/docs/handoffs/2026-08-13-doubao-ui-duration-membership-01.md
@@ -1,0 +1,39 @@
+# DOUBAO-UI-DURATION-MEMBERSHIP-01 候选报告
+
+## 治理与冻结验收包
+
+已读取总架构师治理规则、项目 `AGENTS.md`、README、ROADMAP、DESIGN、最新 UI capability handoff 和相关源码测试。
+
+- P0-1：适配当前 4–15 秒 Radix 时长滑杆，只操作页面可见控件
+- P0-2：选择时长后检测会员订阅 iframe，返回 `membership_required` 并停止
+- P0-3：增强 Adapter 会员 iframe 只读取证和 dry-run 回归
+
+## 实现
+
+- 识别 `role=slider` 且 `aria-valuemin=0`、`aria-valuemax=11` 的当前时长滑杆。
+- 使用 Electron 页面输入事件聚焦滑杆，从 Home 起按目标秒数移动；不改写请求参数。
+- 控件未出现时保留旧下拉 UI 兼容回退；两者均失败时明确报错。
+- 选择后回读 `aria-valuenow`，并只读检查 iframe `title/src` 中的订阅/会员证据。
+- 发现会员动作时发送 Escape 关闭本次弹窗，返回 `membership_required`，禁止最终提交。
+- Adapter 自检将跨域订阅 iframe 作为结构化 `action_required` 证据。
+
+## 边界
+
+- 11–15 秒出现会员窗口仅是当前账户、当前页面的观察，不是永久平台规则。
+- 未点击购买、支付或升级确认。
+- 未发送真实生成、未消耗额度、未读取 Cookie/Token。
+- 未修改已合并的官方无水印解析链。
+
+## 自动化门禁
+
+- 会员与能力专项：49 pass / 0 fail
+- 全量：494 pass / 0 fail（15 files）
+- TypeScript：通过
+- 工程结构与 contracts 边界：通过
+- Production build：通过
+- 修改文件 ESLint：0 error（既有 warnings 未扩项清理）
+- `git diff --check`：通过
+
+## 状态
+
+代码候选已实现并通过自动化门禁，等待总架构师复验。未部署。

--- a/src/automation/doubaoAdapter.ts
+++ b/src/automation/doubaoAdapter.ts
@@ -77,6 +77,19 @@ export async function runAdapterSelfCheck(webview: WebviewHandle): Promise<Adapt
           break;
         }
       }
+      // 当前购买会员界面是跨域订阅 iframe，父页面无法读取正文；
+      // 只能使用平台提供的 iframe title/src 作为机器可读动作证据。
+      if (!membershipText) {
+        var frames = document.querySelectorAll('iframe');
+        for (var f = 0; f < frames.length; f++) {
+          var frameTitle = (frames[f].getAttribute('title') || '').trim();
+          var frameSrc = frames[f].getAttribute('src') || '';
+          if (frameTitle.indexOf('订阅') >= 0 || /subscribe|subscription|membership|upgrade/i.test(frameSrc)) {
+            membershipText = '升级会员';
+            break;
+          }
+        }
+      }
       var accountTier = 'unknown';
       var tierMatch = bodyText.match(/(?:当前套餐|当前会员|会员等级)[:：\\s]*(免费|标准|加强|高级)(?:会员)?/);
       if (tierMatch) accountTier = tierMatch[1];

--- a/src/utils/doubaoBridge.ts
+++ b/src/utils/doubaoBridge.ts
@@ -2647,6 +2647,111 @@ export async function configureVideoOptions(
   const durationTexts = [durationSec + ' 秒', durationSec + '秒', config.duration];
 
   /**
+   * 当前豆包视频时长使用 Radix slider：aria-valuemin=0 对应 4 秒，
+   * aria-valuemax=11 对应 15 秒。必须使用真实键盘事件操作控件，不能改写请求。
+   */
+  const selectDurationSlider = async (): Promise<'selected' | 'membership_required' | 'not_found'> => {
+    if (typeof webview.sendInputEvent !== 'function') return 'not_found';
+    const targetSeconds = Number(durationSec);
+    if (!Number.isInteger(targetSeconds) || targetSeconds < 4 || targetSeconds > 15) return 'not_found';
+
+    const findSlider = async (): Promise<{ ok: boolean; clickPos?: string; triggerClickPos?: string }> => safeExecuteJS<{
+      ok: boolean;
+      clickPos?: string;
+      triggerClickPos?: string;
+    }>(webview, `
+        (function() {
+          var sliders = Array.from(document.querySelectorAll('[role="slider"]'));
+          var slider = sliders.find(function(el) {
+            var r = el.getBoundingClientRect();
+            return r.width > 0 && r.height > 0
+              && el.getAttribute('aria-valuemin') === '0'
+              && el.getAttribute('aria-valuemax') === '11';
+          });
+          if (!slider) {
+            var trigger = Array.from(document.querySelectorAll('button[aria-haspopup="menu"]')).find(function(el) {
+              var r = el.getBoundingClientRect();
+              var text = (el.innerText || '').trim();
+              return r.width > 0 && r.height > 0 && /(?:自动|\d+:\d+)\s*·\s*\d+s/.test(text);
+            });
+            if (!trigger) return { ok: false };
+            var tr = trigger.getBoundingClientRect();
+            return {
+              ok: false,
+              triggerClickPos: Math.round(tr.left + tr.width / 2) + ',' + Math.round(tr.top + tr.height / 2)
+            };
+          }
+          var r = slider.getBoundingClientRect();
+          slider.focus();
+          return {
+            ok: true,
+            clickPos: Math.round(r.left + r.width / 2) + ',' + Math.round(r.top + r.height / 2)
+          };
+        })()
+      `,
+      3000,
+      'find_video_duration_slider',
+    ).catch((): { ok: boolean } => ({ ok: false }));
+
+    let slider = await findSlider();
+    if (!slider.ok && slider.triggerClickPos) {
+      const [triggerX, triggerY] = slider.triggerClickPos.split(',').map(Number);
+      if (Number.isFinite(triggerX) && Number.isFinite(triggerY)) {
+        webview.sendInputEvent({ type: 'mouseMove', x: triggerX, y: triggerY });
+        webview.sendInputEvent({ type: 'mouseDown', x: triggerX, y: triggerY, button: 'left', clickCount: 1 });
+        webview.sendInputEvent({ type: 'mouseUp', x: triggerX, y: triggerY, button: 'left', clickCount: 1 });
+        await sleep(350);
+        slider = await findSlider();
+      }
+    }
+    if (!slider.ok || !slider.clickPos) return 'not_found';
+
+    const [x, y] = slider.clickPos.split(',').map(Number);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return 'not_found';
+    webview.sendInputEvent({ type: 'mouseMove', x, y });
+    webview.sendInputEvent({ type: 'mouseDown', x, y, button: 'left', clickCount: 1 });
+    webview.sendInputEvent({ type: 'mouseUp', x, y, button: 'left', clickCount: 1 });
+    webview.sendInputEvent({ type: 'keyDown', keyCode: 'Home' });
+    webview.sendInputEvent({ type: 'keyUp', keyCode: 'Home' });
+    for (let step = 0; step < targetSeconds - 4; step += 1) {
+      webview.sendInputEvent({ type: 'keyDown', keyCode: 'Right' });
+      webview.sendInputEvent({ type: 'keyUp', keyCode: 'Right' });
+    }
+    await sleep(500);
+
+    const result = await safeExecuteJS<{ selected: boolean; membershipRequired: boolean }>(
+      webview,
+      `
+        (function() {
+          var expected = ${JSON.stringify(targetSeconds - 4)};
+          var slider = Array.from(document.querySelectorAll('[role="slider"]')).find(function(el) {
+            return el.getAttribute('aria-valuemin') === '0' && el.getAttribute('aria-valuemax') === '11';
+          });
+          var subscription = Array.from(document.querySelectorAll('iframe')).some(function(frame) {
+            var title = (frame.getAttribute('title') || '').trim();
+            var src = frame.getAttribute('src') || '';
+            return title.indexOf('订阅') >= 0 || /subscribe|subscription|membership|upgrade/i.test(src);
+          });
+          return {
+            selected: !!slider && Number(slider.getAttribute('aria-valuenow')) === expected,
+            membershipRequired: subscription
+          };
+        })()
+      `,
+      3000,
+      'verify_video_duration_slider',
+    );
+
+    if (result.membershipRequired) {
+      // 关闭本次参数探测触发的订阅窗口，确保失败后不遗留购买界面。
+      webview.sendInputEvent({ type: 'keyDown', keyCode: 'Escape' });
+      webview.sendInputEvent({ type: 'keyUp', keyCode: 'Escape' });
+      return 'membership_required';
+    }
+    return result.selected ? 'selected' : 'not_found';
+  };
+
+  /**
    * 点击下拉选项：先点击触发按钮展开下拉，再选择目标选项
    * triggerTexts: 触发按钮的文本关键词（用于找到并点击展开）
    * optionTexts: 下拉选项的文本
@@ -3147,9 +3252,16 @@ export async function configureVideoOptions(
 
   // 2. 选择时长
   console.log(`[doubaoBridge] 配置视频时长: ${config.duration}（仅使用页面可见控件）`);
-  const durationTriggers = ['4s', '5s', '10s', '15s', '时长'];
-  if (!await selectDropdownOption(durationTriggers, durationTexts, '视频时长')) {
-    throw new Error(`视频时长配置失败: ${config.duration}`);
+  const sliderResult = await selectDurationSlider();
+  if (sliderResult === 'membership_required') {
+    throw new Error(`membership_required: ${config.duration} 需要会员操作，已停止提交`);
+  }
+  if (sliderResult === 'not_found') {
+    // 兼容尚未切换到滑杆 UI 的旧页面；仍只允许页面可见控件。
+    const durationTriggers = ['4s', '5s', '10s', '15s', '时长'];
+    if (!await selectDropdownOption(durationTriggers, durationTexts, '视频时长')) {
+      throw new Error(`视频时长配置失败: ${config.duration}`);
+    }
   }
   await sleep(300);
 

--- a/src/utils/doubaoBridge.ts
+++ b/src/utils/doubaoBridge.ts
@@ -2672,7 +2672,7 @@ export async function configureVideoOptions(
             var trigger = Array.from(document.querySelectorAll('button[aria-haspopup="menu"]')).find(function(el) {
               var r = el.getBoundingClientRect();
               var text = (el.innerText || '').trim();
-              return r.width > 0 && r.height > 0 && /(?:自动|\d+:\d+)\s*·\s*\d+s/.test(text);
+              return r.width > 0 && r.height > 0 && /(?:自动|[0-9]+:[0-9]+)[ ]*·[ ]*[0-9]+s/.test(text);
             });
             if (!trigger) return { ok: false };
             var tr = trigger.getBoundingClientRect();

--- a/tests/unit/videoCapability.test.ts
+++ b/tests/unit/videoCapability.test.ts
@@ -482,6 +482,17 @@ describe('豆包新 UI 只读能力快照与 dry-run', () => {
       .toEqual({ ok: false, code: 'membership_required', finalSubmit: false });
   });
 
+  it.each(['购买会员', '升级会员', '会员专享'])('真实会员动作证据 %s 均 fail-closed', (membershipDialogText) => {
+    const snapshot = buildDoubaoCapabilitySnapshot({
+      pageUrl: 'https://www.doubao.com/',
+      bodyText: pageText,
+      membershipDialogText,
+    });
+    expect(snapshot.membership.availability).toBe('action_required');
+    expect(evaluateDryRunSelection(snapshot, { model: 'Seedance 2.0 Fast', duration: 15, aspectRatio: '9:16' }))
+      .toEqual({ ok: false, code: 'membership_required', finalSubmit: false });
+  });
+
   it.each([
     ['unknown', false, 'membership_required'],
     ['selectable', true, 'ready'],


### PR DESCRIPTION
## What changed

- Operate Doubao's current 4–15 second Radix duration slider through visible page input events.
- Read back the slider value after selection.
- Detect the current cross-origin subscription iframe and fail closed with `membership_required`.
- Close the probe-triggered membership dialog with Escape and stop before final generation.
- Extend the adapter self-check and table-driven membership evidence tests.

## Safety

- No request-body duration patching
- No membership purchase or upgrade confirmation
- No real image/video generation or quota use
- Current-account observations are not encoded as permanent platform entitlements

## Verification

- Capability/membership tests: 49/49 pass
- Full suite: 494/494 pass
- TypeScript checks: pass
- Project/contracts boundaries: pass
- Production build: pass
- Changed-file lint: 0 errors
