### PR TITLE
fix(main): make IPC registration lifecycle-safe

### DIFF
--- a/docs/handoffs/2026-08-13-doubao-stability-ipc-lifecycle-01.md
+++ b/docs/handoffs/2026-08-13-doubao-stability-ipc-lifecycle-01.md
@@ -1,0 +1,34 @@
+# DOUBAO-STABILITY-IPC-LIFECYCLE-01
+
+## 治理与冻结范围
+
+已读取总架构师治理规则、项目 AGENTS.md、README、DESIGN、ROADMAP 和相关主进程源码。本包核心目标是让 IPC 注册可重入并在退出时对称释放。
+
+- P0-1：重复初始化前替换旧 handler，不触发 Electron 重复注册异常。
+- P0-2：每个注册批次返回幂等 disposer；旧 disposer 不得误删新 handler。
+- P0-3：应用退出时清理 handle/on 注册；不在模块导入时访问 `app.getPath()`。
+
+非目标：不改账号、任务和下载业务语义，不改网页自动化，不部署、不真实生成。
+
+## 实现
+
+- 新增 IPC 生命周期协调器，以 registry + channel owner token 管理 handler 所有权。
+- 四个业务 IPC 注册器改为显式 channel 清单并返回 disposer。
+- 主进程重复注册前先清理；退出时移除业务 handler、系统 handler 和窗口事件 listener。
+- app 路径仍只在注册后的处理函数或实际存储调用中读取。
+
+## 验证
+
+- IPC 生命周期专项：4 pass / 0 fail。
+- TypeScript：主进程、渲染进程、测试配置均通过。
+- 全局 ESLint：0 error / 145 warnings（阈值 149，未新增清理旧债）。
+- 工程与 contracts 边界：全部通过；49 个 handle/invoke 与 3 个 on/send 通道一致。
+- 全量单测：16 files，498 pass / 0 fail。
+- 生产构建：renderer + main 通过。
+- `git diff --check`：通过。
+
+首次全量测试在 C 盘系统 Temp 空间为 0 时因 `ENOSPC` 中止；代码门禁此前已通过。复验将 TEMP/TMP 指向 D 盘本任务专用目录后，498 项全量与构建自然通过。未删除或清理任何用户文件。
+
+## 状态
+
+候选门禁通过，等待提交与 CI。未部署。

--- a/main/ipc/accounts.ts
+++ b/main/ipc/accounts.ts
@@ -8,6 +8,7 @@ import { ipcMain, session } from 'electron';
 import { readJSON, writeJSON } from '../utils/store';
 import { normalizeAccounts } from '../utils/persistenceNormalization';
 import { v4 as uuidv4 } from 'uuid';
+import { replaceIpcHandlers } from './lifecycle';
 import type {
   Account,
   AccountAddParams,
@@ -140,7 +141,15 @@ async function clearAccountSession(partition: string): Promise<void> {
 
 // ==================== IPC 处理器注册 ====================
 
-export function registerAccountIPC(): void {
+const ACCOUNT_IPC_CHANNELS = [
+  'accounts:list', 'accounts:add', 'accounts:update', 'accounts:delete',
+  'accounts:refresh', 'accounts:setStatus', 'accounts:setPinned',
+  'accounts:updateScheduling', 'accounts:updateHealth',
+  'accounts:updateSeedanceQuota', 'accounts:getPartition',
+] as const;
+
+export function registerAccountIPC(): () => void {
+  const dispose = replaceIpcHandlers(ipcMain, ACCOUNT_IPC_CHANNELS);
   // ---- 获取所有账号 ----
   ipcMain.handle('accounts:list', async (): Promise<Account[]> => {
     // loadAccounts 已内置运行时归一化（额度日期重置、健康/调度补全、重复 ID 去重）
@@ -415,4 +424,5 @@ export function registerAccountIPC(): void {
   );
 
   console.log('[IPC] 账号管理模块已注册');
+  return dispose;
 }

--- a/main/ipc/lifecycle.ts
+++ b/main/ipc/lifecycle.ts
@@ -1,0 +1,45 @@
+/**
+ * IPC handler 生命周期协调器。
+ *
+ * Electron 的 ipcMain.handle 不允许同一 channel 重复注册。开发热重载或测试
+ * 重复初始化时，先替换旧 handler；旧注册批次的 disposer 只能清理自己仍持有
+ * 的 channel，不能误删后来注册的新 handler。
+ */
+
+export interface IpcHandlerRegistry {
+  removeHandler(channel: string): void;
+}
+
+const activeOwners = new WeakMap<object, Map<string, symbol>>();
+
+export function replaceIpcHandlers(
+  registry: IpcHandlerRegistry,
+  channels: readonly string[],
+): () => void {
+  const uniqueChannels = [...new Set(channels)];
+  if (uniqueChannels.length !== channels.length || uniqueChannels.some((channel) => !channel.trim())) {
+    throw new Error('IPC channel 清单必须为非空且不可重复');
+  }
+
+  const registryKey = registry as object;
+  const owners = activeOwners.get(registryKey) ?? new Map<string, symbol>();
+  activeOwners.set(registryKey, owners);
+  const owner = Symbol('ipc-registration');
+
+  for (const channel of uniqueChannels) {
+    registry.removeHandler(channel);
+    owners.set(channel, owner);
+  }
+
+  let disposed = false;
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    for (const channel of uniqueChannels) {
+      if (owners.get(channel) !== owner) continue;
+      registry.removeHandler(channel);
+      owners.delete(channel);
+    }
+    if (owners.size === 0) activeOwners.delete(registryKey);
+  };
+}

--- a/main/ipc/projects.ts
+++ b/main/ipc/projects.ts
@@ -2,6 +2,7 @@ import { ipcMain } from 'electron';
 import { v4 as uuidv4 } from 'uuid';
 import { readJSON, writeJSON } from '../utils/store';
 import type { Project, ProjectAddParams, ProjectUpdateParams, ProjectIdParams } from '@doubao-studio/contracts';
+import { replaceIpcHandlers } from './lifecycle';
 
 // 领域模型接口和 IPC DTO 已迁移至 @doubao-studio/contracts。
 // 此处通过 import type 引用，不产生运行时依赖。
@@ -26,7 +27,10 @@ export function getDefaultProjectId(): string {
   return DEFAULT_PROJECT_ID;
 }
 
-export function registerProjectIPC(): void {
+const PROJECT_IPC_CHANNELS = ['projects:list', 'projects:add', 'projects:update', 'projects:delete'] as const;
+
+export function registerProjectIPC(): () => void {
+  const dispose = replaceIpcHandlers(ipcMain, PROJECT_IPC_CHANNELS);
   loadProjects();
   ipcMain.handle('projects:list', async () => loadProjects());
   ipcMain.handle('projects:add', async (_event, params: ProjectAddParams) => {
@@ -58,4 +62,5 @@ export function registerProjectIPC(): void {
     return { success: true };
   });
   console.log('[IPC] 项目管理模块已注册');
+  return dispose;
 }

--- a/main/ipc/system.ts
+++ b/main/ipc/system.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { getDataDir, readJSON, writeJSON } from '../utils/store';
 import type { LogEntry, LogAppendParams } from '@doubao-studio/contracts';
+import { replaceIpcHandlers } from './lifecycle';
 
 // 领域模型接口和 IPC DTO 已迁移至 @doubao-studio/contracts。
 // 此处通过 import type 引用，不产生运行时依赖。
@@ -12,7 +13,13 @@ const ARRAY_DATA_FILES = new Set(['projects.json', 'accounts.json', 'tasks.json'
 
 import { compareVersions } from '../utils/version';
 
-export function registerSystemIPC(): void {
+const SYSTEM_IPC_CHANNELS = [
+  'logs:list', 'logs:append', 'logs:clear', 'system:checkIntegrity',
+  'system:exportBackup', 'system:restoreBackup', 'system:exportProject', 'system:checkUpdate',
+] as const;
+
+export function registerSystemIPC(): () => void {
+  const dispose = replaceIpcHandlers(ipcMain, SYSTEM_IPC_CHANNELS);
   ipcMain.handle('logs:list', async () => readJSON<LogEntry[]>('logs.json', []));
   ipcMain.handle('logs:append', async (_event, entry: LogAppendParams) => {
     const logs = readJSON<LogEntry[]>('logs.json', []);
@@ -142,4 +149,5 @@ export function registerSystemIPC(): void {
       return { success: true, currentVersion, latestVersion, hasUpdate: compareVersions(latestVersion, currentVersion) > 0, url: release.html_url, name: release.name };
     } catch (error: any) { return { success: false, error: error.message }; }
   });
+  return dispose;
 }

--- a/main/ipc/tasks.ts
+++ b/main/ipc/tasks.ts
@@ -10,6 +10,7 @@ import { normalizeTasks, normalizeDownloadJobs } from '../utils/persistenceNorma
 import { validateDownloadResponse, classifyDownloadException } from '../utils/downloadValidation';
 import { v4 as uuidv4 } from 'uuid';
 import { getDefaultProjectId } from './projects';
+import { replaceIpcHandlers } from './lifecycle';
 import type {
   GenerationMode,
   VideoModel,
@@ -218,7 +219,18 @@ function recoverInterruptedTasks(): void {
 
 // ==================== IPC 处理器注册 ====================
 
-export function registerTaskIPC(): void {
+const TASK_IPC_CHANNELS = [
+  'tasks:list', 'tasks:add', 'tasks:assign', 'tasks:updateStatus', 'tasks:update',
+  'tasks:delete', 'tasks:retry', 'tasks:batchPause', 'tasks:updateRuntime',
+  'tasks:acquireLock', 'tasks:importCsv', 'tasks:releaseLock',
+  'tasks:getCompletedOutputs', 'tasks:selectImages', 'tasks:selectAudio',
+  'tasks:readFileAsBase64', 'tasks:downloadOutputs', 'tasks:listDownloads',
+  'tasks:exportDiagnostics', 'tasks:validateArtifact', 'tasks:saveAdapterReport',
+  'tasks:selectAdapterRules', 'settings:get', 'settings:save', 'tasks:selectSaveDir',
+] as const;
+
+export function registerTaskIPC(): () => void {
+  const dispose = replaceIpcHandlers(ipcMain, TASK_IPC_CHANNELS);
   recoverInterruptedTasks();
   // 在任何新下载开始前，仅恢复上次进程遗留的下载状态。
   loadDownloadJobs();
@@ -1004,4 +1016,5 @@ export function registerTaskIPC(): void {
   );
 
   console.log('[IPC] 任务调度模块已注册');
+  return dispose;
 }

--- a/main/main.ts
+++ b/main/main.ts
@@ -16,6 +16,7 @@ import { registerTaskIPC } from './ipc/tasks';
 import { registerProjectIPC } from './ipc/projects';
 import { registerSystemIPC } from './ipc/system';
 import { writeCrashLog } from './utils/logger';
+import { replaceIpcHandlers } from './ipc/lifecycle';
 
 // ==================== 常量 ====================
 
@@ -30,6 +31,7 @@ const DOUBAO_URL = 'https://www.doubao.com';
 let mainWindow: BrowserWindow | null = null;
 /** 应用是否正在退出，防止退出过程中创建新窗口或重新调度任务 */
 let isQuitting = false;
+let unregisterIPC: (() => void) | null = null;
 
 // ==================== 窗口创建 ====================
 
@@ -88,11 +90,16 @@ function createMainWindow(): BrowserWindow {
 // ==================== IPC 注册 ====================
 
 function registerIPC(): void {
+  unregisterIPC?.();
   // 注册业务模块 IPC
-  registerAccountIPC();
-  registerProjectIPC();
-  registerTaskIPC();
-  registerSystemIPC();
+  const disposers = [
+    registerAccountIPC(),
+    registerProjectIPC(),
+    registerTaskIPC(),
+    registerSystemIPC(),
+  ];
+
+  disposers.push(replaceIpcHandlers(ipcMain, ['system:getVersion']));
 
   // ---- 系统级 IPC ----
 
@@ -102,21 +109,33 @@ function registerIPC(): void {
   });
 
   // 窗口控制
-  ipcMain.on('window:minimize', () => {
+  const minimizeWindow = (): void => {
     mainWindow?.minimize();
-  });
+  };
 
-  ipcMain.on('window:toggleMaximize', () => {
+  const toggleMaximizeWindow = (): void => {
     if (mainWindow?.isMaximized()) {
       mainWindow.unmaximize();
     } else {
       mainWindow?.maximize();
     }
-  });
+  };
 
-  ipcMain.on('window:close', () => {
+  const closeWindow = (): void => {
     mainWindow?.close();
-  });
+  };
+
+  ipcMain.on('window:minimize', minimizeWindow);
+  ipcMain.on('window:toggleMaximize', toggleMaximizeWindow);
+  ipcMain.on('window:close', closeWindow);
+
+  unregisterIPC = () => {
+    for (const dispose of disposers.reverse()) dispose();
+    ipcMain.removeListener('window:minimize', minimizeWindow);
+    ipcMain.removeListener('window:toggleMaximize', toggleMaximizeWindow);
+    ipcMain.removeListener('window:close', closeWindow);
+    unregisterIPC = null;
+  };
 
   console.log('[Main] IPC 模块全部注册完成');
 }
@@ -206,6 +225,7 @@ if (!gotLock) {
   // 应用退出前清理：标记退出状态，防止退出过程中创建新窗口
   app.on('before-quit', () => {
     isQuitting = true;
+    unregisterIPC?.();
     mainWindow = null;
   });
 }

--- a/tests/unit/ipcLifecycle.test.ts
+++ b/tests/unit/ipcLifecycle.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { replaceIpcHandlers } from '../../main/ipc/lifecycle';
+
+describe('IPC handler 生命周期', () => {
+  it('注册前移除同名旧 handler，disposer 可重复调用', () => {
+    const registry = { removeHandler: vi.fn() };
+    const dispose = replaceIpcHandlers(registry, ['alpha', 'beta']);
+
+    expect(registry.removeHandler.mock.calls).toEqual([['alpha'], ['beta']]);
+    dispose();
+    dispose();
+
+    expect(registry.removeHandler.mock.calls).toEqual([
+      ['alpha'], ['beta'], ['alpha'], ['beta'],
+    ]);
+  });
+
+  it('旧注册批次的 disposer 不会移除后来替换的新 handler', () => {
+    const registry = { removeHandler: vi.fn() };
+    const disposeOld = replaceIpcHandlers(registry, ['shared']);
+    const disposeNew = replaceIpcHandlers(registry, ['shared']);
+
+    disposeOld();
+    expect(registry.removeHandler).toHaveBeenCalledTimes(2);
+
+    disposeNew();
+    expect(registry.removeHandler).toHaveBeenCalledTimes(3);
+  });
+
+  it.each([
+    ['重复 channel', ['same', 'same']],
+    ['空 channel', ['valid', '']],
+  ])('%s 时 fail-closed', (_label, channels) => {
+    const registry = { removeHandler: vi.fn() };
+    expect(() => replaceIpcHandlers(registry, channels)).toThrow('IPC channel 清单必须为非空且不可重复');
+    expect(registry.removeHandler).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- make all Electron IPC handler registration replace-safe
- add idempotent ownership-aware disposal for hot reload and shutdown
- remove window listeners and handlers during app exit

## Validation
- 498/498 tests
- TypeScript, ESLint (145/149), project/contracts checks, build PASS
- no real generation, membership purchase, deployment, or release