### PR TITLE
fix(tasks): enforce renewable owner-bound leases

### DIFF
--- a/docs/handoffs/2026-08-13-doubao-task-lease-heartbeat-01.md
+++ b/docs/handoffs/2026-08-13-doubao-task-lease-heartbeat-01.md
@@ -1,0 +1,30 @@
+# DOUBAO-TASK-LEASE-HEARTBEAT-01
+
+## 治理与冻结范围
+
+已读取总架构师治理规则、项目规则、ROADMAP、最新 IPC 生命周期 handoff 与任务锁源码。本包只收敛任务租约所有权。
+
+- P0-1：2 分钟短租约、30 秒续租、过期接管。
+- P0-2：续租和释放必须匹配 owner，缺失/错误 owner fail-closed。
+- P0-3：AutomationEngine 持锁期间心跳；续租失败时中止执行并释放本地占用。
+
+非目标：不改队列排序和依赖策略，不运行真实生成，不迁移用户数据，不部署。
+
+## 状态
+
+## 实现与验证
+
+- 纯函数租约状态机：2 分钟有效期、正确 owner 续租、过期后新租约接管。
+- IPC 新增 `tasks:renewLock`，release 的 owner 改为必填且错误 owner 不写盘。
+- AutomationEngine 每 30 秒续租；返回失败或 IPC 异常均中止控制器、停止心跳并释放本地占用。
+- 页面重载恢复仅在快照含原 owner 时释放，不再执行无 owner 解锁。
+- 租约/AutomationEngine/contracts 专项：54 pass / 0 fail。
+- TypeScript：主进程、渲染进程、测试配置全部通过。
+- 工程/contracts 边界：50 个 handle/invoke、3 个 on/send，全部一致。
+- 全量单测：18 files，507 pass / 0 fail。
+- 全局 ESLint：0 error（既有 warning 未扩项清理）。
+- 生产构建与 `git diff --check`：通过。
+
+系统 C 盘 Temp 空间为 0，本包沿用 D 盘任务专用 TEMP/TMP 完成验证；未删除用户文件。
+
+候选门禁通过，等待提交与 CI。未部署。

--- a/main/ipc/tasks.ts
+++ b/main/ipc/tasks.ts
@@ -11,6 +11,7 @@ import { validateDownloadResponse, classifyDownloadException } from '../utils/do
 import { v4 as uuidv4 } from 'uuid';
 import { getDefaultProjectId } from './projects';
 import { replaceIpcHandlers } from './lifecycle';
+import { acquireTaskLease, canReleaseTaskLease, renewTaskLease } from '../utils/taskLease';
 import type {
   GenerationMode,
   VideoModel,
@@ -29,6 +30,7 @@ import type {
   TaskUpdateStatusParams,
   TaskUpdateRuntimeParams,
   TaskAcquireLockParams,
+  TaskRenewLockParams,
   TaskReleaseLockParams,
   TaskImportCsvParams,
   TaskUpdateInput,
@@ -222,7 +224,7 @@ function recoverInterruptedTasks(): void {
 const TASK_IPC_CHANNELS = [
   'tasks:list', 'tasks:add', 'tasks:assign', 'tasks:updateStatus', 'tasks:update',
   'tasks:delete', 'tasks:retry', 'tasks:batchPause', 'tasks:updateRuntime',
-  'tasks:acquireLock', 'tasks:importCsv', 'tasks:releaseLock',
+  'tasks:acquireLock', 'tasks:renewLock', 'tasks:importCsv', 'tasks:releaseLock',
   'tasks:getCompletedOutputs', 'tasks:selectImages', 'tasks:selectAudio',
   'tasks:readFileAsBase64', 'tasks:downloadOutputs', 'tasks:listDownloads',
   'tasks:exportDiagnostics', 'tasks:validateArtifact', 'tasks:saveAdapterReport',
@@ -490,16 +492,26 @@ export function registerTaskIPC(): () => void {
         new Date(item.lock.expiresAt).getTime() > now
       );
       if (accountConflict) return { success: false, error: '该账号已经被其他任务锁定' };
-      if (task.lock && task.lock.ownerId !== params.ownerId && new Date(task.lock.expiresAt).getTime() > now) {
-        return { success: false, error: '任务已经被其他执行器锁定' };
-      }
-      task.lock = {
-        ownerId: params.ownerId,
-        acquiredAt: new Date(now).toISOString(),
-        expiresAt: new Date(now + 4 * 60 * 60 * 1000).toISOString(),
-      };
+      const decision = acquireTaskLease(task.lock, params.ownerId, now);
+      if (!decision.success) return decision;
+      task.lock = decision.lock;
       task.updatedAt = new Date().toISOString();
       saveTasks(tasks);
+      return { success: true, task };
+    }
+  );
+
+  ipcMain.handle(
+    'tasks:renewLock',
+    async (_event, params: TaskRenewLockParams): Promise<{ success: boolean; task?: Task; error?: string }> => {
+      const tasks = loadTasks();
+      const task = tasks.find((item) => item.id === params.taskId);
+      if (!task) return { success: false, error: '任务不存在' };
+      const decision = renewTaskLease(task.lock, params.ownerId, Date.now());
+      if (!decision.success) return decision;
+      task.lock = decision.lock;
+      task.updatedAt = new Date().toISOString();
+      if (!saveTasks(tasks)) return { success: false, error: '任务锁续租写入失败' };
       return { success: true, task };
     }
   );
@@ -591,14 +603,16 @@ export function registerTaskIPC(): () => void {
 
   ipcMain.handle(
     'tasks:releaseLock',
-    async (_event, params: TaskReleaseLockParams): Promise<{ success: boolean }> => {
+    async (_event, params: TaskReleaseLockParams): Promise<{ success: boolean; error?: string }> => {
       const tasks = loadTasks();
       const task = tasks.find((item) => item.id === params.taskId);
-      if (task?.lock && (!params.ownerId || task.lock.ownerId === params.ownerId)) {
-        task.lock = undefined;
-        task.updatedAt = new Date().toISOString();
-        saveTasks(tasks);
+      if (!task) return { success: false, error: '任务不存在' };
+      if (!canReleaseTaskLease(task.lock, params.ownerId)) {
+        return { success: false, error: '任务锁 owner 不匹配' };
       }
+      task.lock = undefined;
+      task.updatedAt = new Date().toISOString();
+      if (!saveTasks(tasks)) return { success: false, error: '任务锁释放写入失败' };
       return { success: true };
     }
   );

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -63,7 +63,9 @@ const electronAPI = {
       ipcRenderer.invoke('tasks:updateRuntime', { taskId, ...patch }),
     acquireLock: (taskId: string, ownerId: string): Promise<{ success: boolean; task?: Task; error?: string }> =>
       ipcRenderer.invoke('tasks:acquireLock', { taskId, ownerId }),
-    releaseLock: (taskId: string, ownerId?: string): Promise<{ success: boolean }> =>
+    renewLock: (taskId: string, ownerId: string): Promise<{ success: boolean; task?: Task; error?: string }> =>
+      ipcRenderer.invoke('tasks:renewLock', { taskId, ownerId }),
+    releaseLock: (taskId: string, ownerId: string): Promise<{ success: boolean; error?: string }> =>
       ipcRenderer.invoke('tasks:releaseLock', { taskId, ownerId }),
     importCsv: (projectId?: string): Promise<any> => ipcRenderer.invoke('tasks:importCsv', { projectId }),
     update: (taskId: string, updates: {

--- a/main/utils/taskLease.ts
+++ b/main/utils/taskLease.ts
@@ -1,0 +1,58 @@
+import type { TaskLock } from '@doubao-studio/contracts';
+
+export const TASK_LEASE_DURATION_MS = 2 * 60 * 1000;
+export const TASK_LEASE_HEARTBEAT_MS = 30 * 1000;
+
+export type LeaseDecision =
+  | { success: true; lock: TaskLock }
+  | { success: false; error: string };
+
+function isOwnerIdValid(ownerId: string): boolean {
+  return typeof ownerId === 'string' && ownerId.trim().length > 0;
+}
+
+export function acquireTaskLease(
+  current: TaskLock | undefined,
+  ownerId: string,
+  nowMs: number,
+): LeaseDecision {
+  if (!isOwnerIdValid(ownerId)) return { success: false, error: '执行器 ownerId 无效' };
+  const currentExpiresAt = current ? Date.parse(current.expiresAt) : Number.NaN;
+  if (current && current.ownerId !== ownerId && Number.isFinite(currentExpiresAt) && currentExpiresAt > nowMs) {
+    return { success: false, error: '任务已经被其他执行器锁定' };
+  }
+
+  return {
+    success: true,
+    lock: {
+      ownerId,
+      acquiredAt: current?.ownerId === ownerId && currentExpiresAt > nowMs
+        ? current.acquiredAt
+        : new Date(nowMs).toISOString(),
+      expiresAt: new Date(nowMs + TASK_LEASE_DURATION_MS).toISOString(),
+    },
+  };
+}
+
+export function renewTaskLease(
+  current: TaskLock | undefined,
+  ownerId: string,
+  nowMs: number,
+): LeaseDecision {
+  if (!current) return { success: false, error: '任务锁不存在或已过期' };
+  if (!isOwnerIdValid(ownerId) || current.ownerId !== ownerId) {
+    return { success: false, error: '任务锁 owner 不匹配' };
+  }
+  const expiresAt = Date.parse(current.expiresAt);
+  if (!Number.isFinite(expiresAt) || expiresAt <= nowMs) {
+    return { success: false, error: '任务锁不存在或已过期' };
+  }
+  return {
+    success: true,
+    lock: { ...current, expiresAt: new Date(nowMs + TASK_LEASE_DURATION_MS).toISOString() },
+  };
+}
+
+export function canReleaseTaskLease(current: TaskLock | undefined, ownerId: string): boolean {
+  return !!current && isOwnerIdValid(ownerId) && current.ownerId === ownerId;
+}

--- a/packages/contracts/src/dto/electron-api.ts
+++ b/packages/contracts/src/dto/electron-api.ts
@@ -121,7 +121,8 @@ export interface ElectronAPI {
       result?: string;
     }) => Promise<TaskResult>;
     acquireLock: (taskId: string, ownerId: string) => Promise<TaskResult>;
-    releaseLock: (taskId: string, ownerId?: string) => Promise<{ success: boolean }>;
+    renewLock: (taskId: string, ownerId: string) => Promise<TaskResult>;
+    releaseLock: (taskId: string, ownerId: string) => Promise<TaskOperationResult>;
     importCsv: (projectId?: string) => Promise<CsvImportResult>;
     update: (taskId: string, updates: TaskUpdateInput) => Promise<TaskResult>;
     delete: (taskId: string) => Promise<TaskOperationResult>;

--- a/packages/contracts/src/dto/tasks.ts
+++ b/packages/contracts/src/dto/tasks.ts
@@ -74,9 +74,14 @@ export interface TaskAcquireLockParams {
   ownerId: string;
 }
 
+export interface TaskRenewLockParams {
+  taskId: string;
+  ownerId: string;
+}
+
 export interface TaskReleaseLockParams {
   taskId: string;
-  ownerId?: string;
+  ownerId: string;
 }
 
 export interface TaskImportCsvParams {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -58,6 +58,7 @@ export type {
   TaskUpdateStatusParams,
   TaskUpdateRuntimeParams,
   TaskAcquireLockParams,
+  TaskRenewLockParams,
   TaskReleaseLockParams,
   TaskImportCsvParams,
   TaskUpdateInput,

--- a/src/automation/AutomationEngine.ts
+++ b/src/automation/AutomationEngine.ts
@@ -1,11 +1,20 @@
+import type { ElectronAPI } from '@doubao-studio/contracts';
+
 interface Reservation {
   taskId: string;
   accountId: string;
   ownerId: string;
   controller?: AbortController;
+  heartbeat?: ReturnType<typeof setInterval>;
 }
 
-class AutomationEngine {
+const LEASE_HEARTBEAT_MS = 30_000;
+
+function getElectronAPI(): ElectronAPI {
+  return (window as unknown as { electronAPI: ElectronAPI }).electronAPI;
+}
+
+export class AutomationEngine {
   private reservations = new Map<string, Reservation>();
   private accountTasks = new Map<string, string>();
 
@@ -17,13 +26,37 @@ class AutomationEngine {
 
     this.reservations.set(taskId, { taskId, accountId, ownerId });
     this.accountTasks.set(accountId, taskId);
-    const result = await window.electronAPI.tasks.acquireLock(taskId, ownerId);
+    const result = await getElectronAPI().tasks.acquireLock(taskId, ownerId);
     if (!result.success) {
       this.reservations.delete(taskId);
       if (this.accountTasks.get(accountId) === taskId) this.accountTasks.delete(accountId);
       return { ok: false, error: result.error || '任务锁定失败' };
     }
+    const reservation = this.reservations.get(taskId);
+    if (reservation) {
+      reservation.heartbeat = setInterval(() => {
+        void this.renew(reservation);
+      }, LEASE_HEARTBEAT_MS);
+    }
     return { ok: true };
+  }
+
+  private async renew(reservation: Reservation): Promise<void> {
+    let error = '未知错误';
+    try {
+      const result = await getElectronAPI().tasks.renewLock(reservation.taskId, reservation.ownerId);
+      if (result.success) return;
+      error = result.error || error;
+    } catch (reason: unknown) {
+      error = reason instanceof Error ? reason.message : String(reason);
+    }
+    reservation.controller?.abort();
+    if (reservation.heartbeat) clearInterval(reservation.heartbeat);
+    this.reservations.delete(reservation.taskId);
+    if (this.accountTasks.get(reservation.accountId) === reservation.taskId) {
+      this.accountTasks.delete(reservation.accountId);
+    }
+    console.error(`[AutomationEngine] 任务租约续租失败，已中止执行: ${error}`);
   }
 
   createController(taskId: string, accountId: string): AbortController {
@@ -50,12 +83,12 @@ class AutomationEngine {
   async release(taskId: string): Promise<void> {
     const reservation = this.reservations.get(taskId);
     if (!reservation) {
-      await window.electronAPI.tasks.releaseLock(taskId);
       return;
     }
+    if (reservation.heartbeat) clearInterval(reservation.heartbeat);
     this.reservations.delete(taskId);
     if (this.accountTasks.get(reservation.accountId) === taskId) this.accountTasks.delete(reservation.accountId);
-    await window.electronAPI.tasks.releaseLock(taskId, reservation.ownerId);
+    await getElectronAPI().tasks.releaseLock(taskId, reservation.ownerId);
   }
 }
 

--- a/src/store/useTaskStore.ts
+++ b/src/store/useTaskStore.ts
@@ -155,7 +155,9 @@ export const useTaskStore = create<TaskState>((set, get) => ({
             errorInfo: { code: 'cancelled', message: '应用界面重新载入，任务已安全暂停', recoverable: true, detectedAt: now },
             runtime: task.runtime ? { stage: 'paused', message: '应用界面重新载入，任务已安全暂停', stageStartedAt: now, lastHeartbeatAt: now } : undefined,
           });
-          await window.electronAPI.tasks.releaseLock(task.id);
+          if (task.lock?.ownerId) {
+            await window.electronAPI.tasks.releaseLock(task.id, task.lock.ownerId);
+          }
         }
         if (activeTasks.length > 0) tasks = await window.electronAPI.tasks.list();
       }

--- a/tests/unit/automationEngineLease.test.ts
+++ b/tests/unit/automationEngineLease.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AutomationEngine } from '../../src/automation/AutomationEngine';
+
+const acquireLock = vi.fn();
+const renewLock = vi.fn();
+const releaseLock = vi.fn();
+
+describe('AutomationEngine 租约心跳', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    acquireLock.mockReset().mockResolvedValue({ success: true });
+    renewLock.mockReset().mockResolvedValue({ success: true });
+    releaseLock.mockReset().mockResolvedValue({ success: true });
+    vi.stubGlobal('window', {
+      electronAPI: { tasks: { acquireLock, renewLock, releaseLock } },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('持锁期间每 30 秒续租，释放后停止心跳并携带 owner', async () => {
+    const engine = new AutomationEngine();
+    await engine.reserve('task-1', 'account-1', 'owner-1');
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(renewLock).toHaveBeenCalledWith('task-1', 'owner-1');
+
+    await engine.release('task-1');
+    expect(releaseLock).toHaveBeenCalledWith('task-1', 'owner-1');
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(renewLock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['返回失败', () => renewLock.mockResolvedValueOnce({ success: false, error: 'lost' })],
+    ['IPC 抛错', () => renewLock.mockRejectedValueOnce(new Error('offline'))],
+  ])('%s 时中止控制器并释放本地 reservation', async (_label, arrange) => {
+    const engine = new AutomationEngine();
+    await engine.reserve('task-2', 'account-2', 'owner-2');
+    const controller = engine.createController('task-2', 'account-2');
+    const abortSpy = vi.spyOn(controller, 'abort');
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    arrange();
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(abortSpy).toHaveBeenCalledOnce();
+    expect(engine.isReserved('task-2')).toBe(false);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('任务租约续租失败'));
+    consoleSpy.mockRestore();
+  });
+});

--- a/tests/unit/taskLease.test.ts
+++ b/tests/unit/taskLease.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  TASK_LEASE_DURATION_MS,
+  acquireTaskLease,
+  canReleaseTaskLease,
+  renewTaskLease,
+} from '../../main/utils/taskLease';
+
+const NOW = Date.parse('2026-08-13T00:00:00.000Z');
+
+describe('任务短租约', () => {
+  it('创建 2 分钟短租约，并由同 owner 续租且保留 acquiredAt', () => {
+    const acquired = acquireTaskLease(undefined, 'worker-a', NOW);
+    expect(acquired.success).toBe(true);
+    if (!acquired.success) return;
+    expect(Date.parse(acquired.lock.expiresAt) - NOW).toBe(TASK_LEASE_DURATION_MS);
+
+    const renewed = renewTaskLease(acquired.lock, 'worker-a', NOW + 30_000);
+    expect(renewed.success).toBe(true);
+    if (!renewed.success) return;
+    expect(renewed.lock.acquiredAt).toBe(acquired.lock.acquiredAt);
+    expect(Date.parse(renewed.lock.expiresAt)).toBe(NOW + 30_000 + TASK_LEASE_DURATION_MS);
+  });
+
+  it('有效租约拒绝其他 owner，过期后允许接管并重置 acquiredAt', () => {
+    const current = {
+      ownerId: 'worker-a',
+      acquiredAt: new Date(NOW).toISOString(),
+      expiresAt: new Date(NOW + 1_000).toISOString(),
+    };
+    expect(acquireTaskLease(current, 'worker-b', NOW + 500)).toEqual({
+      success: false,
+      error: '任务已经被其他执行器锁定',
+    });
+    const takeover = acquireTaskLease(current, 'worker-b', NOW + 1_001);
+    expect(takeover.success).toBe(true);
+    if (takeover.success) expect(takeover.lock.acquiredAt).toBe(new Date(NOW + 1_001).toISOString());
+
+    const reacquired = acquireTaskLease(current, 'worker-a', NOW + 1_001);
+    expect(reacquired.success).toBe(true);
+    if (reacquired.success) expect(reacquired.lock.acquiredAt).toBe(new Date(NOW + 1_001).toISOString());
+  });
+
+  it.each([
+    ['缺失锁', undefined, 'worker-a'],
+    ['错误 owner', { ownerId: 'worker-a', acquiredAt: new Date(NOW).toISOString(), expiresAt: new Date(NOW + 1_000).toISOString() }, 'worker-b'],
+    ['已过期', { ownerId: 'worker-a', acquiredAt: new Date(NOW).toISOString(), expiresAt: new Date(NOW).toISOString() }, 'worker-a'],
+  ])('%s 时续租 fail-closed', (_label, lock, ownerId) => {
+    expect(renewTaskLease(lock, ownerId, NOW).success).toBe(false);
+  });
+
+  it('仅正确 owner 可以释放', () => {
+    const lock = { ownerId: 'worker-a', acquiredAt: new Date(NOW).toISOString(), expiresAt: new Date(NOW + 1_000).toISOString() };
+    expect(canReleaseTaskLease(lock, 'worker-a')).toBe(true);
+    expect(canReleaseTaskLease(lock, 'worker-b')).toBe(false);
+    expect(canReleaseTaskLease(lock, '')).toBe(false);
+    expect(canReleaseTaskLease(undefined, 'worker-a')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- replace 4-hour task locks with 2-minute renewable leases
- add 30-second AutomationEngine heartbeat and fail-closed abort on renewal loss
- require matching owner for renewal and release; allow expired takeover

## Validation
- 54/54 lease, engine and contract tests
- 507/507 full tests
- TypeScript, ESLint (145/149), 50/50 IPC boundary, build PASS
- no real generation, user-data migration, deployment, or release