### PR TITLE
fix(webview): dispose browser resources safely

### DIFF
--- a/docs/handoffs/2026-08-13-doubao-webview-lifecycle-01.md
+++ b/docs/handoffs/2026-08-13-doubao-webview-lifecycle-01.md
@@ -1,0 +1,25 @@
+# DOUBAO-WEBVIEW-LIFECYCLE-01
+
+## 治理与冻结范围
+
+已读取总架构师治理规则、项目规则、ROADMAP、最新稳定性 handoff 与 BrowserPanel 源码。本包只处理 webview 资源生命周期。
+
+- P0-1：账号删除时注销监听器、停止定时器、移除 DOM。
+- P0-2：组件卸载时清理所有 webview 资源并中止执行控制器。
+- P0-3：已释放作用域的异步回调不得更新组件状态。
+
+非目标：不改页面选择器、生成流程和 UI，不运行真实生成，不部署。
+
+## 实现与验证
+
+- 新增每账号资源作用域，集中持有监听器与 timer，并提供幂等 dispose。
+- 6 个 webview 加载/导航事件、2 秒轮询和 60 秒超时统一登记。
+- 账号删除清理对应作用域、DOM、加载状态和相关 AbortController。
+- 组件卸载以稳定 ref 快照清理全部作用域、webview 与控制器。
+- 所有加载状态回调先验证 `scope.active`，释放后不再触发状态更新。
+- 专项：3 pass / 0 fail；全量：19 files，510 pass / 0 fail。
+- TypeScript、全局 ESLint（0 error / 既有 warnings）、工程/contracts 边界、生产构建和 `git diff --check` 全部通过。
+
+系统 C 盘 Temp 空间为 0，本包使用 D 盘任务专用 TEMP/TMP 验证，未删除用户文件。
+
+候选门禁通过，等待提交与 CI。未部署。

--- a/src/components/BrowserPanel.tsx
+++ b/src/components/BrowserPanel.tsx
@@ -41,6 +41,8 @@ import {
   manualResolveVideoArtifact,
 } from '../utils/doubaoBridge';
 import type { VideoArtifactResolution } from '../utils/videoArtifactResolver';
+import { createWebviewResourceScope } from '../utils/webviewLifecycle';
+import type { WebviewResourceScope } from '../utils/webviewLifecycle';
 
 /** 将解析结果转换为用户可读的消息 */
 const formatResolutionMessage = (result: VideoArtifactResolution): string => {
@@ -82,8 +84,8 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
   const abortControllersRef = useRef<Map<string, AbortController>>(new Map());
   const pendingRestartTasksRef = useRef<Map<string, TaskUpdateInput>>(new Map());
   const manualVideoUsageRef = useRef<Set<string>>(new Set());
-  /** 每个账号的定时器集合，用于组件卸载或账号删除时统一清理 */
-  const timersRef = useRef<Map<string, Set<ReturnType<typeof setInterval> | ReturnType<typeof setTimeout>>>>(new Map());
+  /** 每个账号的 webview 监听器与定时器作用域。 */
+  const resourceScopesRef = useRef<Map<string, WebviewResourceScope>>(new Map());
 
   const [activeLoading, setActiveLoading] = useState(true);
   const [loadText, setLoadText] = useState('加载豆包中...');
@@ -143,19 +145,50 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
     : undefined;
   const activeAutoMsg = activeAccount ? (accountAutoMsg[activeAccount.id] || '') : '';
 
-  // ---- 组件卸载时清理所有定时器，防止泄漏 ----
+  // ---- 组件卸载时清理所有 webview 资源与执行控制器 ----
   useEffect(() => {
+    const resourceScopes = resourceScopesRef.current;
+    const registry = registryRef.current;
+    const loadingMap = loadingMapRef.current;
+    const controllers = abortControllersRef.current;
+    const runningAccounts = runningRef.current;
     return () => {
-      timersRef.current.forEach((timers, accountId) => {
-        timers.forEach((t) => {
-          clearInterval(t);
-          clearTimeout(t);
-        });
-        console.log(`[BrowserPanel] 组件卸载，清理账号 ${accountId} 的定时器`);
-      });
-      timersRef.current.clear();
+      resourceScopes.forEach((scope) => scope.dispose());
+      resourceScopes.clear();
+      registry.forEach((webview) => webview.remove());
+      registry.clear();
+      loadingMap.clear();
+      controllers.forEach((controller) => controller.abort());
+      controllers.clear();
+      runningAccounts.clear();
+      console.log('[BrowserPanel] 组件卸载，已清理全部 webview 资源');
     };
   }, []);
+
+  /** 幂等释放指定账号的 webview、监听器和定时器。 */
+  const disposeAccountWebview = (accountId: string): void => {
+    resourceScopesRef.current.get(accountId)?.dispose();
+    resourceScopesRef.current.delete(accountId);
+    const webview = registryRef.current.get(accountId);
+    if (webview) {
+      webview.remove();
+      registryRef.current.delete(accountId);
+    }
+    loadingMapRef.current.delete(accountId);
+    const state = useTaskStore.getState();
+    const taskIds = new Set(
+      state.tasks
+        .filter((task) => task.assignedAccountId === accountId)
+        .map((task) => task.id),
+    );
+    const executingTaskId = state.executingTasks[accountId];
+    if (executingTaskId) taskIds.add(executingTaskId);
+    for (const taskId of taskIds) {
+      abortControllersRef.current.get(taskId)?.abort();
+      abortControllersRef.current.delete(taskId);
+    }
+    runningRef.current.delete(accountId);
+  };
 
   // ---- webview 池动态管理（账号增删同步） ----
   const accountsKey = accounts.map(a => a.id).join(',');
@@ -168,10 +201,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
     // 清理已删除账号的 webview 和定时器
     registryRef.current.forEach((webview, accountId) => {
       if (!accountIds.has(accountId)) {
-        clearAccountTimers(accountId);
-        container.removeChild(webview);
-        registryRef.current.delete(accountId);
-        loadingMapRef.current.delete(accountId);
+        disposeAccountWebview(accountId);
         console.log(`[BrowserPanel] 已移除账号 ${accountId} 的 webview`);
       }
     });
@@ -197,6 +227,8 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
     if (registryRef.current.has(account.id)) return;
 
     const accId = account.id;
+    const scope = createWebviewResourceScope();
+    resourceScopesRef.current.set(accId, scope);
     loadingMapRef.current.set(accId, true);
 
     const webview = document.createElement('webview') as HTMLWebViewElement;
@@ -212,16 +244,11 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
 
     // 统一加载完成处理
     const markLoaded = (evt: string) => {
+      if (!scope.active) return;
       if (!loadingMapRef.current.get(accId)) return; // 已标记完成，不重复处理
       loadingMapRef.current.set(accId, false);
-      if (pollInterval) {
-        clearInterval(pollInterval);
-        timersRef.current.get(accId)?.delete(pollInterval);
-      }
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-        timersRef.current.get(accId)?.delete(timeoutId);
-      }
+      scope.clearTimer(pollInterval);
+      scope.clearTimer(timeoutId);
       console.log(`[BrowserPanel] markLoaded: ${accId} via ${evt}`);
       const cur = useAccountStore.getState().selectedAccountId;
       if (accId === cur) {
@@ -230,7 +257,8 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
       }
     };
 
-    webview.addEventListener('did-start-loading', () => {
+    scope.listen(webview, 'did-start-loading', () => {
+      if (!scope.active) return;
       loadingMapRef.current.set(accId, true);
       const cur = useAccountStore.getState().selectedAccountId;
       if (accId === cur) {
@@ -239,16 +267,17 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
       }
     });
 
-    webview.addEventListener('did-finish-load', () => markLoaded('did-finish-load'));
-    webview.addEventListener('did-stop-loading', () => markLoaded('did-stop-loading'));
-    webview.addEventListener('did-navigate', () => markLoaded('did-navigate'));
-    webview.addEventListener('did-navigate-in-page', () => markLoaded('did-navigate-in-page'));
-    webview.addEventListener('dom-ready', () => {
+    scope.listen(webview, 'did-finish-load', () => markLoaded('did-finish-load'));
+    scope.listen(webview, 'did-stop-loading', () => markLoaded('did-stop-loading'));
+    scope.listen(webview, 'did-navigate', () => markLoaded('did-navigate'));
+    scope.listen(webview, 'did-navigate-in-page', () => markLoaded('did-navigate-in-page'));
+    scope.listen(webview, 'dom-ready', () => {
       markLoaded('dom-ready');
     });
-    webview.addEventListener('did-fail-load', () => {
+    scope.listen(webview, 'did-fail-load', () => {
+      if (!scope.active) return;
       loadingMapRef.current.set(accId, false);
-      clearAccountTimers(accId);
+      scope.clearTimers();
       const cur = useAccountStore.getState().selectedAccountId;
       if (accId === cur) {
         setActiveLoading(false);
@@ -265,7 +294,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
     pollInterval = setInterval(() => {
       const wv = registryRef.current.get(accId);
       if (!wv) {
-        clearAccountTimers(accId);
+        scope.clearTimers();
         return;
       }
       
@@ -277,37 +306,20 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
         markLoaded('poll');
       }
     }, 2000);
+    scope.trackTimer(pollInterval);
 
     // 60s 后停止轮询
     timeoutId = setTimeout(() => {
-      if (pollInterval) clearInterval(pollInterval);
+      scope.clearTimer(pollInterval);
+      if (!scope.active) return;
       if (loadingMapRef.current.get(accId)) {
         console.warn(`[BrowserPanel] 60s 超时，强制清除加载状态: ${accId}`);
         markLoaded('timeout');
       }
-      if (timeoutId) timersRef.current.get(accId)?.delete(timeoutId);
-      if (pollInterval) timersRef.current.get(accId)?.delete(pollInterval);
+      scope.clearTimer(timeoutId);
+      scope.clearTimer(pollInterval);
     }, 60000);
-
-    // 注册定时器，用于账号删除或组件卸载时统一清理
-    if (!timersRef.current.has(accId)) {
-      timersRef.current.set(accId, new Set());
-    }
-    timersRef.current.get(accId)!.add(pollInterval);
-    timersRef.current.get(accId)!.add(timeoutId);
-  };
-
-  /** 清理指定账号的所有定时器 */
-  const clearAccountTimers = (accountId: string) => {
-    const timers = timersRef.current.get(accountId);
-    if (timers) {
-      timers.forEach((t) => {
-        clearInterval(t);
-        clearTimeout(t);
-      });
-      timers.clear();
-      timersRef.current.delete(accountId);
-    }
+    scope.trackTimer(timeoutId);
   };
 
   // ---- 切换可见性 ----

--- a/src/utils/webviewLifecycle.ts
+++ b/src/utils/webviewLifecycle.ts
@@ -1,0 +1,65 @@
+export interface WebviewEventTarget {
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject): void;
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject): void;
+}
+
+type TimerHandle = number | ReturnType<typeof setTimeout> | ReturnType<typeof setInterval>;
+
+export interface WebviewResourceScope {
+  readonly active: boolean;
+  listen(target: WebviewEventTarget, type: string, listener: EventListenerOrEventListenerObject): void;
+  trackTimer(timer: TimerHandle): void;
+  clearTimer(timer: TimerHandle | undefined): void;
+  clearTimers(): void;
+  dispose(): void;
+}
+
+/** 将单个 webview 的监听器和定时器绑定为一个可幂等释放的资源作用域。 */
+export function createWebviewResourceScope(): WebviewResourceScope {
+  const listeners: Array<{
+    target: WebviewEventTarget;
+    type: string;
+    listener: EventListenerOrEventListenerObject;
+  }> = [];
+  const timers = new Set<TimerHandle>();
+  let active = true;
+
+  const clearTimer = (timer: TimerHandle | undefined): void => {
+    if (timer === undefined) return;
+    clearInterval(timer);
+    clearTimeout(timer);
+    timers.delete(timer);
+  };
+
+  const clearTimers = (): void => {
+    for (const timer of [...timers]) clearTimer(timer);
+  };
+
+  return {
+    get active() {
+      return active;
+    },
+    listen(target, type, listener) {
+      if (!active) throw new Error('webview 资源作用域已释放');
+      target.addEventListener(type, listener);
+      listeners.push({ target, type, listener });
+    },
+    trackTimer(timer) {
+      if (!active) {
+        clearTimer(timer);
+        return;
+      }
+      timers.add(timer);
+    },
+    clearTimer,
+    clearTimers,
+    dispose() {
+      if (!active) return;
+      active = false;
+      clearTimers();
+      for (const { target, type, listener } of listeners.splice(0)) {
+        target.removeEventListener(type, listener);
+      }
+    },
+  };
+}

--- a/tests/unit/webviewLifecycle.test.ts
+++ b/tests/unit/webviewLifecycle.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createWebviewResourceScope } from '../../src/utils/webviewLifecycle';
+
+describe('webview 资源作用域', () => {
+  it('dispose 注销全部监听器、清理定时器且可重复调用', () => {
+    vi.useFakeTimers();
+    const target = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    const listener = vi.fn();
+    const scope = createWebviewResourceScope();
+    scope.listen(target, 'dom-ready', listener);
+    scope.trackTimer(setInterval(listener, 1_000));
+    scope.trackTimer(setTimeout(listener, 2_000));
+
+    scope.dispose();
+    scope.dispose();
+    vi.advanceTimersByTime(3_000);
+
+    expect(scope.active).toBe(false);
+    expect(target.removeEventListener).toHaveBeenCalledOnce();
+    expect(target.removeEventListener).toHaveBeenCalledWith('dom-ready', listener);
+    expect(listener).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('clearTimer 只停止指定 timer，clearTimers 停止其余 timer', () => {
+    vi.useFakeTimers();
+    const first = vi.fn();
+    const second = vi.fn();
+    const scope = createWebviewResourceScope();
+    const firstTimer = setTimeout(first, 1_000);
+    const secondTimer = setTimeout(second, 1_000);
+    scope.trackTimer(firstTimer);
+    scope.trackTimer(secondTimer);
+
+    scope.clearTimer(firstTimer);
+    vi.advanceTimersByTime(1_000);
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledOnce();
+    scope.clearTimers();
+    scope.dispose();
+    vi.useRealTimers();
+  });
+
+  it('释放后拒绝注册新监听器，并立即清除新 timer', () => {
+    vi.useFakeTimers();
+    const listener = vi.fn();
+    const target = { addEventListener: vi.fn(), removeEventListener: vi.fn() };
+    const scope = createWebviewResourceScope();
+    scope.dispose();
+
+    expect(() => scope.listen(target, 'load', listener)).toThrow('webview 资源作用域已释放');
+    scope.trackTimer(setTimeout(listener, 1_000));
+    vi.advanceTimersByTime(1_000);
+    expect(listener).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- bind every webview listener and timer to an idempotent per-account resource scope
- dispose listeners, timers, DOM nodes and matching controllers when accounts disappear
- dispose all browser resources on component unmount and block stale callbacks

## Validation
- 3/3 lifecycle tests
- 510/510 full tests
- TypeScript, ESLint, IPC/contracts checks, build PASS
- no selector, generation, user-data, deployment, or release changes