### PR TITLE
fix(downloads): recover owned partial files safely

### DIFF
--- a/docs/handoffs/2026-08-13-doubao-download-recovery-01.md
+++ b/docs/handoffs/2026-08-13-doubao-download-recovery-01.md
@@ -1,0 +1,24 @@
+# DOUBAO-DOWNLOAD-RECOVERY-01
+
+## 治理与冻结范围
+
+已读取总架构师治理规则、项目规则、ROADMAP、稳定性 handoff 与下载源码。本包只处理下载状态写入放大和临时文件恢复。
+
+- P0-1：下载列表纯读取，只有归一化/恢复实际变化才写盘。
+- P0-2：当前失败只删除调用方持有的精确临时路径。
+- P0-3：启动恢复仅清理已登记 downloading job 的安全 ID 精确后缀文件，目录边界 fail-closed。
+
+非目标：不改下载地址解析、响应验证或保存目录，不下载真实文件，不部署。
+
+## 实现与验证
+
+- 移除 `tasks:listDownloads` 的无条件全量写回。
+- 新增中断恢复纯函数：只扫描 job.saveDir 顶层，要求安全 job ID、精确 `.<jobId>.part` 后缀和解析后的同目录边界。
+- 当前下载 catch 只删除本次明确记录的 `temporaryPath`，不再遍历删除同后缀未知文件。
+- 目录不存在或 job ID 不安全时只将状态恢复为 failed，保留未知文件并记录 warning。
+- 下载恢复/验证/归一化专项：101 pass / 0 fail；全量：20 files，514 pass / 0 fail。
+- TypeScript、全局 ESLint（0 error / 142 warnings）、工程/contracts 边界、生产构建和 `git diff --check` 全部通过。
+
+验证仅在 D 盘任务专用 TEMP 目录创建和删除测试文件；未读取或删除真实下载文件。系统 C 盘 Temp 空间仍为 0，未清理用户文件。
+
+候选门禁通过，等待提交与 CI。未部署。

--- a/main/ipc/tasks.ts
+++ b/main/ipc/tasks.ts
@@ -12,6 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { getDefaultProjectId } from './projects';
 import { replaceIpcHandlers } from './lifecycle';
 import { acquireTaskLease, canReleaseTaskLease, renewTaskLease } from '../utils/taskLease';
+import { recoverInterruptedDownloads, removeExactDownloadPart } from '../utils/downloadRecovery';
 import type {
   GenerationMode,
   VideoModel,
@@ -128,15 +129,10 @@ function loadDownloadJobs(): DownloadJob[] {
   // 下载中断恢复：将上次进程遗留的 'downloading' 状态标记为 'failed'
   if (!downloadRecoveryApplied) {
     downloadRecoveryApplied = true;
-    let changed = false;
-    for (const job of jobs) {
-      if (job.status !== 'downloading') continue;
-      job.status = 'failed';
-      job.error = '程序退出导致下载中断，可重新下载';
-      job.updatedAt = new Date().toISOString();
-      changed = true;
-    }
-    if (changed) writeJSON(DOWNLOAD_STORE_FILE, jobs);
+    const fs = require('fs') as typeof import('fs');
+    const path = require('path') as typeof import('path');
+    const recovery = recoverInterruptedDownloads(fs, path, jobs, new Date().toISOString());
+    if (recovery.recovered > 0) writeJSON(DOWNLOAD_STORE_FILE, jobs);
   }
   return jobs;
 }
@@ -767,6 +763,7 @@ export function registerTaskIPC(): () => void {
             jobs.push(job);
             jobIds.push(job.id);
             saveDownloadJobs(jobs);
+            let temporaryPath: string | undefined;
             try {
               const controller = new AbortController();
               const timeout = setTimeout(() => controller.abort(), 60000);
@@ -802,7 +799,7 @@ export function registerTaskIPC(): () => void {
               }
               const fileName = `${task.taskId.substring(0, 8)}_${outputIndex + 1}${ext}`;
               const filePath = getAvailableDownloadPath(fs, path, saveDir, fileName);
-              const temporaryPath = `${filePath}.${job.id}.part`;
+              temporaryPath = `${filePath}.${job.id}.part`;
               fs.writeFileSync(temporaryPath, buffer);
               fs.renameSync(temporaryPath, filePath);
               job.status = 'done';
@@ -813,9 +810,7 @@ export function registerTaskIPC(): () => void {
               downloadedCount++;
             } catch (e: any) {
               try {
-                for (const entry of fs.readdirSync(saveDir)) {
-                  if (entry.endsWith(`.${job.id}.part`)) fs.unlinkSync(path.join(saveDir, entry));
-                }
+                removeExactDownloadPart(fs, path, saveDir, temporaryPath, job.id);
               } catch {}
               const classified = classifyDownloadException(e);
               failures.push(`${task.taskId.slice(0, 8)}: ${classified.message}`);
@@ -843,9 +838,7 @@ export function registerTaskIPC(): () => void {
   );
 
   ipcMain.handle('tasks:listDownloads', async (): Promise<DownloadJob[]> => {
-    const jobs = loadDownloadJobs();
-    saveDownloadJobs(jobs);
-    return jobs;
+    return loadDownloadJobs();
   });
 
   ipcMain.handle(

--- a/main/utils/downloadRecovery.ts
+++ b/main/utils/downloadRecovery.ts
@@ -1,0 +1,65 @@
+import type * as Fs from 'fs';
+import type * as Path from 'path';
+import type { DownloadJob } from '@doubao-studio/contracts';
+
+export interface DownloadRecoveryResult {
+  recovered: number;
+  removedParts: string[];
+}
+
+/** 仅清理由已登记 downloading job 精确拥有、且位于 saveDir 顶层的临时文件。 */
+export function recoverInterruptedDownloads(
+  fs: typeof Fs,
+  path: typeof Path,
+  jobs: DownloadJob[],
+  now: string,
+): DownloadRecoveryResult {
+  const removedParts: string[] = [];
+  let recovered = 0;
+
+  for (const job of jobs) {
+    if (job.status !== 'downloading') continue;
+    recovered++;
+    const resolvedDir = path.resolve(job.saveDir);
+    const safeJobId = /^[A-Za-z0-9._-]+$/.test(job.id) ? job.id : null;
+    const suffix = safeJobId ? `.${safeJobId}.part` : null;
+    try {
+      if (!suffix) throw new Error('下载记录 ID 不是安全文件标识');
+      for (const entry of fs.readdirSync(resolvedDir, { withFileTypes: true })) {
+        if (!entry.isFile() || !entry.name.endsWith(suffix)) continue;
+        const candidate = path.resolve(resolvedDir, entry.name);
+        if (path.dirname(candidate) !== resolvedDir || !path.basename(candidate).endsWith(suffix)) continue;
+        fs.unlinkSync(candidate);
+        removedParts.push(candidate);
+      }
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[Downloads] 中断临时文件清理失败 (${job.id}): ${message}`);
+    }
+    job.status = 'failed';
+    job.error = '程序退出导致下载中断，可重新下载';
+    job.updatedAt = now;
+  }
+
+  return { recovered, removedParts };
+}
+
+/** 当前下载失败时只删除调用方持有的精确临时路径。 */
+export function removeExactDownloadPart(
+  fs: typeof Fs,
+  path: typeof Path,
+  saveDir: string,
+  temporaryPath: string | undefined,
+  jobId: string,
+): boolean {
+  if (!temporaryPath) return false;
+  if (!/^[A-Za-z0-9._-]+$/.test(jobId)) return false;
+  const resolvedDir = path.resolve(saveDir);
+  const resolvedPart = path.resolve(temporaryPath);
+  if (path.dirname(resolvedPart) !== resolvedDir || !path.basename(resolvedPart).endsWith(`.${jobId}.part`)) {
+    return false;
+  }
+  if (!fs.existsSync(resolvedPart)) return false;
+  fs.unlinkSync(resolvedPart);
+  return true;
+}

--- a/tests/unit/downloadRecovery.test.ts
+++ b/tests/unit/downloadRecovery.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { DownloadJob } from '@doubao-studio/contracts';
+import { recoverInterruptedDownloads, removeExactDownloadPart } from '../../main/utils/downloadRecovery';
+
+const dirs: string[] = [];
+const makeDir = (): string => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'doubao-download-recovery-'));
+  dirs.push(dir);
+  return dir;
+};
+const job = (saveDir: string, id = 'job-1', status: DownloadJob['status'] = 'downloading'): DownloadJob => ({
+  id, taskId: 'task-1', accountId: null, mode: 'video', url: 'https://example.test/video',
+  status, attempts: 1, saveDir, createdAt: '2026-08-13T00:00:00.000Z', updatedAt: '2026-08-13T00:00:00.000Z',
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of dirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('下载中断恢复', () => {
+  it('只删除 downloading job 精确拥有的 part，未知文件全部保留', () => {
+    const dir = makeDir();
+    const owned = path.join(dir, 'video.mp4.job-1.part');
+    const unknown = path.join(dir, 'video.mp4.other.part');
+    const normal = path.join(dir, 'video.mp4');
+    for (const file of [owned, unknown, normal]) fs.writeFileSync(file, 'x');
+    const jobs = [job(dir), job(dir, 'done-job', 'done')];
+
+    const result = recoverInterruptedDownloads(fs, path, jobs, '2026-08-13T01:00:00.000Z');
+
+    expect(result.recovered).toBe(1);
+    expect(result.removedParts).toEqual([owned]);
+    expect(fs.existsSync(owned)).toBe(false);
+    expect(fs.existsSync(unknown)).toBe(true);
+    expect(fs.existsSync(normal)).toBe(true);
+    expect(jobs[0].status).toBe('failed');
+    expect(jobs[1].status).toBe('done');
+  });
+
+  it('目录不存在时仍恢复状态且不删除其他位置文件', () => {
+    const jobs = [job(path.join(makeDir(), 'missing'))];
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    expect(recoverInterruptedDownloads(fs, path, jobs, '2026-08-13T01:00:00.000Z').recovered).toBe(1);
+    expect(jobs[0].status).toBe('failed');
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it('不安全 job ID 只恢复状态，不匹配或删除文件', () => {
+    const dir = makeDir();
+    const unknown = path.join(dir, 'video.mp4.job.part');
+    fs.writeFileSync(unknown, 'x');
+    const jobs = [job(dir, '../job')];
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const result = recoverInterruptedDownloads(fs, path, jobs, '2026-08-13T01:00:00.000Z');
+    expect(result).toEqual({ recovered: 1, removedParts: [] });
+    expect(fs.existsSync(unknown)).toBe(true);
+    expect(jobs[0].status).toBe('failed');
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it('当前失败只删除精确临时路径，越界和错误后缀均拒绝', () => {
+    const dir = makeDir();
+    const exact = path.join(dir, 'video.mp4.job-1.part');
+    const wrong = path.join(dir, 'video.mp4.other.part');
+    fs.writeFileSync(exact, 'x');
+    fs.writeFileSync(wrong, 'x');
+    expect(removeExactDownloadPart(fs, path, dir, wrong, 'job-1')).toBe(false);
+    expect(fs.existsSync(wrong)).toBe(true);
+    expect(removeExactDownloadPart(fs, path, dir, exact, 'job-1')).toBe(true);
+    expect(fs.existsSync(exact)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- stop rewriting downloads.json on list-only reads
- delete only the exact temporary file owned by the current failed download
- recover interrupted jobs by deleting only safe-ID, same-directory, exact-suffix .part files

## Validation
- 101/101 download-related tests
- 514/514 full tests
- TypeScript, ESLint (142/149), IPC/contracts checks, build PASS
- no real downloads, user-file cleanup, deployment, or release