### PR TITLE
refactor(core): serialize task persistence and emit events

### DIFF
--- a/docs/handoffs/2026-08-13-doubao-core-repository-events-01.md
+++ b/docs/handoffs/2026-08-13-doubao-core-repository-events-01.md
@@ -1,0 +1,41 @@
+# DOUBAO-CORE-REPOSITORY-EVENTS-01 检查报告
+
+## 治理与冻结范围
+
+已读取中央治理、豆包项目 AGENTS、README、ROADMAP、DESIGN、AGENT_EXECUTION_PLAN 和真实源码。
+
+- P0-1：建立 tasks.json 单一 Repository 写入边界。
+- P0-2：陈旧快照写回必须 fail-closed，不覆盖新状态。
+- P0-3：建立与 Capability Schema 语义一致的进程内 v1 任务事件流。
+
+非目标：不实现 CLI/MCP/HTTP，不迁移全部账号/下载 Repository，不改 UI/IPC DTO，不真实生成，不部署。
+
+## 实现摘要
+
+- `TaskRepository` 成为 tasks.json 唯一写入边界，保留既有归一化与备份行为。
+- `read()` 为快照记录内容版本；`replace()` 写盘前重新读取并比较，陈旧或外来快照拒绝写入。
+- 成功提交后按差异发布 created/status/stage/artifact/deleted 事件；失败写入不发布事件。
+- `TaskEventStream` 提供单调 sequence、eventId、游标读取、容量上限和可撤销订阅。
+- IPC channel、返回 DTO、UI Store 和实际生产数据格式不变。
+
+## 边界
+
+- 未触碰当前运行目录 `D:\豆包工作室\doubao-studio-main` 的未提交热更新。
+- 未修改 Alice Agent、ERP、Discord、Cookie、Token、用户素材或运行数据。
+- 未提交、未推送、未创建 PR、未发布、未部署。
+
+## 验证
+
+- 专项与相关回归：26 pass / 0 fail。
+- 项目完整 `validate`：PASS。
+- 全量测试：21 files / 520 pass / 0 fail。
+- TypeScript：0 error。
+- ESLint：0 error；142 条为冻结 warning 基线，低于 149 上限。
+- 工程结构：50 个 handle/invoke、3 个 on/send，fixture 9/9 通过。
+- Contracts 边界：PASS。
+- Renderer/Main 生产构建：PASS。
+- `git diff --check`：PASS。
+
+## 裁决
+
+PASS。三个 P0 均满足，可形成单一候选提交。仍未实现 CLI/MCP/HTTP；下一开发包应先建立最小 `TaskService`，不得把本阶段事件流误写为外部 API 已上线。

--- a/main/core/TaskEventStream.ts
+++ b/main/core/TaskEventStream.ts
@@ -1,0 +1,63 @@
+import { randomUUID } from 'crypto';
+
+export interface TaskEvent {
+  sequence: number;
+  eventId: string;
+  taskId: string;
+  timestamp: string;
+  eventType: string;
+  payload?: Record<string, unknown>;
+}
+
+export type TaskEventListener = (event: TaskEvent) => void;
+
+/**
+ * 进程内 v1 任务事件流。
+ *
+ * 本阶段只建立 Core 事件边界，不承诺跨进程持久化。后续 CLI/API 可使用
+ * after(sequence) 作为游标读取接口，而不需要观察 Zustand 或 JSON 文件。
+ */
+export class TaskEventStream {
+  readonly version = 1;
+  private sequence = 0;
+  private readonly events: TaskEvent[] = [];
+  private readonly listeners = new Set<TaskEventListener>();
+
+  constructor(private readonly capacity = 2_000) {
+    if (!Number.isInteger(capacity) || capacity < 1) {
+      throw new Error('TaskEventStream capacity 必须为正整数');
+    }
+  }
+
+  publish(taskId: string, eventType: string, payload?: Record<string, unknown>): TaskEvent {
+    if (!taskId.trim() || !eventType.trim()) throw new Error('taskId 和 eventType 不能为空');
+    const event: TaskEvent = {
+      sequence: ++this.sequence,
+      eventId: `evt_${randomUUID()}`,
+      taskId,
+      timestamp: new Date().toISOString(),
+      eventType,
+      ...(payload ? { payload } : {}),
+    };
+    this.events.push(event);
+    if (this.events.length > this.capacity) this.events.splice(0, this.events.length - this.capacity);
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch (error) {
+        console.error('[TaskEventStream] 订阅者处理失败:', error);
+      }
+    }
+    return event;
+  }
+
+  after(lastSequence = 0): TaskEvent[] {
+    if (!Number.isInteger(lastSequence) || lastSequence < 0) throw new Error('lastSequence 必须为非负整数');
+    return this.events.filter((event) => event.sequence > lastSequence).map((event) => structuredClone(event));
+  }
+
+  subscribe(listener: TaskEventListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+}

--- a/main/core/TaskRepository.ts
+++ b/main/core/TaskRepository.ts
@@ -1,0 +1,108 @@
+import type { Task } from '@doubao-studio/contracts';
+import type { TaskEventStream } from './TaskEventStream';
+
+export interface TaskNormalizationResult {
+  data: Task[];
+  changed: boolean;
+  warnings: string[];
+}
+
+export interface TaskRepositoryDependencies {
+  read: (filename: string, fallback: unknown) => unknown;
+  write: (filename: string, data: Task[]) => boolean;
+  normalize: (raw: unknown, defaultProjectId: string) => TaskNormalizationResult;
+  defaultProjectId: () => string;
+  events: TaskEventStream;
+  warn?: (message: string, details: string[]) => void;
+}
+
+const STORE_FILE = 'tasks.json';
+
+function fingerprint(tasks: Task[]): string {
+  return JSON.stringify(tasks);
+}
+
+function eventTypeForStatus(status: Task['status']): string {
+  if (status === 'done') return 'task.done';
+  if (status === 'fail') return 'task.failed';
+  if (status === 'paused') return 'task.paused';
+  if (status === 'cancelled') return 'task.cancelled';
+  if (status === 'executing' || status === 'generating') return 'task.started';
+  return 'task.status_changed';
+}
+
+/**
+ * tasks.json 的唯一写入边界。
+ *
+ * read() 返回的数组带有不可见的版本基线；replace() 在真正写盘前重新读取，
+ * 旧快照一律 fail-closed，避免异步 IPC 把其他操作的新数据整体覆盖。
+ */
+export class TaskRepository {
+  private readonly revisions = new WeakMap<Task[], string>();
+  private writing = false;
+
+  constructor(private readonly deps: TaskRepositoryDependencies) {}
+
+  read(): Task[] {
+    const raw = this.deps.read(STORE_FILE, []);
+    const result = this.deps.normalize(raw, this.deps.defaultProjectId());
+    if (result.warnings.length > 0) this.deps.warn?.('[Tasks] 数据归一化告警', result.warnings);
+    if (result.changed && !this.deps.write(STORE_FILE, result.data)) {
+      throw new Error('任务数据归一化写入失败');
+    }
+    this.revisions.set(result.data, fingerprint(result.data));
+    return result.data;
+  }
+
+  replace(tasks: Task[]): boolean {
+    if (this.writing) throw new Error('TASK_REPOSITORY_WRITE_IN_PROGRESS');
+    const expected = this.revisions.get(tasks);
+    if (expected === undefined) throw new Error('TASK_REPOSITORY_UNTRACKED_SNAPSHOT');
+
+    const current = this.deps.normalize(
+      this.deps.read(STORE_FILE, []),
+      this.deps.defaultProjectId(),
+    ).data;
+    if (fingerprint(current) !== expected) throw new Error('TASK_REPOSITORY_STALE_SNAPSHOT');
+
+    this.writing = true;
+    try {
+      if (!this.deps.write(STORE_FILE, tasks)) return false;
+      this.publishDiff(current, tasks);
+      this.revisions.set(tasks, fingerprint(tasks));
+      return true;
+    } finally {
+      this.writing = false;
+    }
+  }
+
+  private publishDiff(before: Task[], after: Task[]): void {
+    const previous = new Map(before.map((task) => [task.id, task]));
+    const next = new Map(after.map((task) => [task.id, task]));
+    for (const task of after) {
+      const old = previous.get(task.id);
+      if (!old) {
+        this.deps.events.publish(task.id, 'task.created', { status: task.status });
+        continue;
+      }
+      if (old.status !== task.status) {
+        this.deps.events.publish(task.id, eventTypeForStatus(task.status), {
+          previousStatus: old.status,
+          status: task.status,
+        });
+      }
+      if (old.runtime?.stage !== task.runtime?.stage && task.runtime?.stage) {
+        this.deps.events.publish(task.id, 'task.stage_changed', { stage: task.runtime.stage });
+      }
+      const oldArtifacts = new Set((old.artifacts || []).map((artifact) => artifact.id));
+      for (const artifact of task.artifacts || []) {
+        if (!oldArtifacts.has(artifact.id)) {
+          this.deps.events.publish(task.id, 'artifact.discovered', { artifactId: artifact.id });
+        }
+      }
+    }
+    for (const task of before) {
+      if (!next.has(task.id)) this.deps.events.publish(task.id, 'task.deleted');
+    }
+  }
+}

--- a/main/ipc/tasks.ts
+++ b/main/ipc/tasks.ts
@@ -13,6 +13,8 @@ import { getDefaultProjectId } from './projects';
 import { replaceIpcHandlers } from './lifecycle';
 import { acquireTaskLease, canReleaseTaskLease, renewTaskLease } from '../utils/taskLease';
 import { recoverInterruptedDownloads, removeExactDownloadPart } from '../utils/downloadRecovery';
+import { TaskEventStream } from '../core/TaskEventStream';
+import { TaskRepository } from '../core/TaskRepository';
 import type {
   GenerationMode,
   VideoModel,
@@ -59,23 +61,21 @@ export type {
 
 // ==================== 数据持久化 ====================
 
-const STORE_FILE = 'tasks.json';
 const DOWNLOAD_STORE_FILE = 'downloads.json';
 let downloadRecoveryApplied = false;
+export const taskEventStream = new TaskEventStream();
+const taskRepository = new TaskRepository({
+  read: (filename, fallback) => readJSON(filename, fallback),
+  write: (filename, data) => writeJSON(filename, data),
+  normalize: normalizeTasks,
+  defaultProjectId: getDefaultProjectId,
+  events: taskEventStream,
+  warn: (message, details) => console.warn(message, details),
+});
 
 /** 读取所有任务（含运行时归一化） */
 function loadTasks(): Task[] {
-  const defaultProjectId = getDefaultProjectId();
-  const raw = readJSON<unknown>(STORE_FILE, []);
-  const result = normalizeTasks(raw, defaultProjectId);
-  // 仅在归一化确实改变数据时写回磁盘
-  if (result.changed) {
-    writeJSON(STORE_FILE, result.data);
-  }
-  if (result.warnings.length > 0) {
-    console.warn('[Tasks] 数据归一化告警:', result.warnings);
-  }
-  return result.data;
+  return taskRepository.read();
 }
 
 function artifactId(url: string): string {
@@ -105,7 +105,7 @@ function appendArtifacts(task: Task, outputs: string[], source: TaskArtifact['so
 import { parseCsv, normalizeCsvMode } from '../utils/csv';
 
 function saveTasks(tasks: Task[]): boolean {
-  return writeJSON(STORE_FILE, tasks);
+  return taskRepository.replace(tasks);
 }
 
 function saveTasksOrError(tasks: Task[]): { success: true } | { success: false; error: string } {

--- a/tests/unit/taskRepository.test.ts
+++ b/tests/unit/taskRepository.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Task } from '@doubao-studio/contracts';
+import { TaskEventStream } from '../../main/core/TaskEventStream';
+import { TaskRepository } from '../../main/core/TaskRepository';
+
+function task(id: string, status: Task['status'] = 'queued'): Task {
+  return {
+    id, prompt: id, assignedAccountId: null, status, mode: 'chat', result: null,
+    outputs: [], artifacts: [], createdAt: '2026-08-13T00:00:00.000Z', updatedAt: '2026-08-13T00:00:00.000Z',
+  };
+}
+
+function fixture(initial: Task[] = []) {
+  let stored = structuredClone(initial);
+  const events = new TaskEventStream(20);
+  const write = vi.fn((_filename: string, value: Task[]) => {
+    stored = structuredClone(value);
+    return true;
+  });
+  const repository = new TaskRepository({
+    read: () => structuredClone(stored),
+    write,
+    normalize: (raw) => ({ data: raw as Task[], changed: false, warnings: [] }),
+    defaultProjectId: () => 'default',
+    events,
+  });
+  return { repository, events, write, stored: () => stored };
+}
+
+describe('TaskRepository 单一写入边界', () => {
+  it('成功写入后发布 created 事件，sequence 单调递增', () => {
+    const { repository, events } = fixture();
+    const tasks = repository.read();
+    tasks.push(task('t1'), task('t2'));
+    expect(repository.replace(tasks)).toBe(true);
+    expect(events.after().map((event) => [event.sequence, event.taskId, event.eventType])).toEqual([
+      [1, 't1', 'task.created'], [2, 't2', 'task.created'],
+    ]);
+  });
+
+  it('拒绝未由 repository read 创建的数组', () => {
+    const { repository, write } = fixture();
+    expect(() => repository.replace([task('foreign')])).toThrow('TASK_REPOSITORY_UNTRACKED_SNAPSHOT');
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('两个调用者持有快照时，拒绝较晚写回的陈旧快照', () => {
+    const { repository, stored } = fixture([task('t1')]);
+    const first = repository.read();
+    const stale = repository.read();
+    first[0].status = 'executing';
+    expect(repository.replace(first)).toBe(true);
+    stale[0].status = 'paused';
+    expect(() => repository.replace(stale)).toThrow('TASK_REPOSITORY_STALE_SNAPSHOT');
+    expect(stored()[0].status).toBe('executing');
+  });
+
+  it('状态、阶段、产物和删除均产生版本化事件', () => {
+    const { repository, events } = fixture([task('t1')]);
+    const tasks = repository.read();
+    tasks[0].status = 'done';
+    tasks[0].runtime = {
+      runId: 'r1', attempt: 1, stage: 'completed', message: '完成',
+      startedAt: '2026-08-13T00:00:00.000Z', stageStartedAt: '2026-08-13T00:00:00.000Z',
+      lastHeartbeatAt: '2026-08-13T00:00:00.000Z',
+      input: { prompt: 't1', mode: 'chat', attachments: [] },
+    };
+    tasks[0].artifacts = [{ id: 'a1', url: 'https://example.invalid/a', kind: 'video', source: 'network', discoveredAt: '2026-08-13T00:00:00.000Z' }];
+    expect(repository.replace(tasks)).toBe(true);
+    const afterUpdate = events.after();
+    expect(afterUpdate.map((event) => event.eventType)).toEqual(['task.done', 'task.stage_changed', 'artifact.discovered']);
+    expect(events.version).toBe(1);
+
+    const deleting = repository.read();
+    deleting.splice(0, 1);
+    expect(repository.replace(deleting)).toBe(true);
+    expect(events.after(afterUpdate.at(-1)!.sequence).map((event) => event.eventType)).toEqual(['task.deleted']);
+  });
+
+  it('订阅可撤销，游标读取返回副本', () => {
+    const stream = new TaskEventStream(2);
+    const listener = vi.fn();
+    const dispose = stream.subscribe(listener);
+    stream.publish('t1', 'task.created');
+    dispose();
+    stream.publish('t1', 'task.started');
+    stream.publish('t1', 'task.done');
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(stream.after().map((event) => event.eventType)).toEqual(['task.started', 'task.done']);
+    const copy = stream.after(1);
+    copy[0].eventType = 'tampered';
+    expect(stream.after(1)[0].eventType).toBe('task.started');
+  });
+
+  it('订阅者异常被隔离，不反向破坏事件提交', () => {
+    const stream = new TaskEventStream();
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    stream.subscribe(() => { throw new Error('listener failed'); });
+    expect(() => stream.publish('t1', 'task.created')).not.toThrow();
+    expect(stream.after()).toHaveLength(1);
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- introduce a single TaskRepository write boundary for tasks.json
- reject stale snapshots before they overwrite newer task state
- publish versioned in-process task and artifact events
- keep existing IPC contracts and UI behavior unchanged

## Validation
- full validate PASS
- 21 files / 520 tests PASS
- TypeScript and production build PASS

No CLI/MCP/HTTP, deployment, generation, account data, or production runtime changes.