### PR TITLE
refactor(core): move task use cases into service

### DIFF
--- a/docs/handoffs/2026-08-13-doubao-core-task-service-01.md
+++ b/docs/handoffs/2026-08-13-doubao-core-task-service-01.md
@@ -1,0 +1,9 @@
+# DOUBAO-CORE-TASK-SERVICE-01 检查报告
+
+已读取中央治理与豆包项目规则。本包只将创建、状态/产物更新、删除和重试四个任务用例从 Electron IPC 抽到 TaskService；Repository 仍为唯一写入边界，IPC DTO 与 UI 行为不变。
+
+禁止范围：CLI/MCP/HTTP、账号/下载/运行时全量迁移、真实生成、部署、Alice Agent/ERP/Discord、凭据与用户数据。
+
+验证结果：专项与相关回归 25 pass / 0 fail；完整 validate PASS；22 个测试文件、526 pass / 0 fail；TypeScript、工程结构、Contracts 边界、Lint warning 基线和生产构建均通过。Repository 冲突/写盘异常已映射为结构化安全失败，不产生未处理 IPC Promise。
+
+裁决：PASS。下一包可继续迁移账号指派、任务编辑与批量暂停；CLI/MCP/HTTP 仍未实现，也未部署。

--- a/main/core/TaskService.ts
+++ b/main/core/TaskService.ts
@@ -1,0 +1,115 @@
+import { randomUUID } from 'crypto';
+import type { GenerationMode, Task, TaskAddParams, TaskUpdateStatusParams } from '@doubao-studio/contracts';
+
+export interface TaskStore {
+  read(): Task[];
+  replace(tasks: Task[]): boolean;
+}
+
+export interface TaskServiceDependencies {
+  store: TaskStore;
+  defaultProjectId: () => string;
+  id?: () => string;
+  now?: () => string;
+}
+
+export type TaskServiceResult<T = undefined> =
+  | ({ success: true } & (T extends undefined ? object : { data: T }))
+  | { success: false; error: string };
+
+const ACTIVE = new Set<Task['status']>(['executing', 'generating', 'waiting_verification']);
+
+function artifactId(url: string): string {
+  let hash = 5381;
+  for (let index = 0; index < url.length; index++) hash = ((hash << 5) + hash) ^ url.charCodeAt(index);
+  return `artifact-${(hash >>> 0).toString(16)}`;
+}
+
+export class TaskService {
+  private readonly id: () => string;
+  private readonly now: () => string;
+
+  constructor(private readonly deps: TaskServiceDependencies) {
+    this.id = deps.id || randomUUID;
+    this.now = deps.now || (() => new Date().toISOString());
+  }
+
+  private persist(tasks: Task[]): boolean {
+    try {
+      return this.deps.store.replace(tasks);
+    } catch {
+      return false;
+    }
+  }
+
+  create(params: TaskAddParams): TaskServiceResult<Task[]> {
+    const prompts = (params.prompts || []).map((prompt) => prompt.trim()).filter(Boolean);
+    if (prompts.length === 0) return { success: false, error: '请输入至少一条提示词' };
+    const tasks = this.deps.store.read();
+    const mode: GenerationMode = params.mode || 'chat';
+    const created = prompts.map((prompt): Task => {
+      const timestamp = this.now();
+      return {
+        id: this.id(), prompt, assignedAccountId: null, status: 'queued', mode,
+        videoConfig: params.videoConfig, attachments: params.attachments,
+        audioAttachment: params.audioAttachment, result: null, outputs: [], artifacts: [],
+        runHistory: [], source: 'manual', dependsOnTaskIds: [],
+        projectId: params.projectId || this.deps.defaultProjectId(),
+        createdAt: timestamp, updatedAt: timestamp,
+      };
+    });
+    tasks.push(...created);
+    if (!this.persist(tasks)) return { success: false, error: '任务数据写入失败，请检查磁盘空间和数据目录权限' };
+    return { success: true, data: created };
+  }
+
+  updateStatus(params: TaskUpdateStatusParams): TaskServiceResult {
+    const tasks = this.deps.store.read();
+    const task = tasks.find((item) => item.id === params.taskId);
+    if (!task) return { success: false, error: '任务不存在' };
+    task.status = params.status;
+    if (params.result !== undefined) task.result = params.result;
+    if (params.outputs !== undefined) {
+      task.outputs = [...new Set(params.outputs.filter(Boolean))];
+      const existing = new Map((task.artifacts || []).map((artifact) => [artifact.url, artifact]));
+      for (const url of task.outputs) {
+        if (!existing.has(url)) existing.set(url, {
+          id: artifactId(url), url,
+          kind: task.mode === 'video' ? 'video' : task.mode === 'image' ? 'image' : 'file',
+          source: 'network', runId: task.runtime?.runId,
+          conversationUrl: task.runtime?.conversationUrl, discoveredAt: this.now(),
+        });
+      }
+      task.artifacts = [...existing.values()];
+    }
+    if (params.status === 'done') task.errorInfo = undefined;
+    task.updatedAt = this.now();
+    if (!this.persist(tasks)) return { success: false, error: '任务数据写入失败，请检查磁盘空间和数据目录权限' };
+    return { success: true };
+  }
+
+  delete(taskId: string): TaskServiceResult {
+    const tasks = this.deps.store.read();
+    const index = tasks.findIndex((task) => task.id === taskId);
+    if (index < 0) return { success: false, error: '任务不存在' };
+    if (ACTIVE.has(tasks[index].status)) return { success: false, error: '任务正在执行，请先暂停后再删除' };
+    const dependentCount = tasks.filter((task) => task.dependsOnTaskIds?.includes(taskId)).length;
+    if (dependentCount > 0) return { success: false, error: `仍有 ${dependentCount} 个任务依赖此任务，请先调整依赖关系` };
+    tasks.splice(index, 1);
+    if (!this.persist(tasks)) return { success: false, error: '任务数据写入失败，请检查磁盘空间和数据目录权限' };
+    return { success: true };
+  }
+
+  retry(taskId: string): TaskServiceResult<Task> {
+    const tasks = this.deps.store.read();
+    const task = tasks.find((item) => item.id === taskId);
+    if (!task) return { success: false, error: '任务不存在' };
+    if (ACTIVE.has(task.status)) return { success: false, error: '任务正在执行中，无法重试' };
+    const timestamp = this.now();
+    task.status = 'queued'; task.result = null; task.outputs = []; task.errorInfo = undefined; task.lock = undefined;
+    if (task.runtime) task.runtime = { ...task.runtime, stage: 'queued', message: '等待执行', stageStartedAt: timestamp, lastHeartbeatAt: timestamp };
+    task.updatedAt = timestamp;
+    if (!this.persist(tasks)) return { success: false, error: '任务数据写入失败，请检查磁盘空间和数据目录权限' };
+    return { success: true, data: task };
+  }
+}

--- a/main/ipc/tasks.ts
+++ b/main/ipc/tasks.ts
@@ -15,12 +15,11 @@ import { acquireTaskLease, canReleaseTaskLease, renewTaskLease } from '../utils/
 import { recoverInterruptedDownloads, removeExactDownloadPart } from '../utils/downloadRecovery';
 import { TaskEventStream } from '../core/TaskEventStream';
 import { TaskRepository } from '../core/TaskRepository';
+import { TaskService } from '../core/TaskService';
 import type {
-  GenerationMode,
   VideoModel,
   VideoDuration,
   VideoAspectRatio,
-  TaskStatus,
   Task,
   TaskErrorInfo,
   TaskRunSnapshot,
@@ -72,34 +71,11 @@ const taskRepository = new TaskRepository({
   events: taskEventStream,
   warn: (message, details) => console.warn(message, details),
 });
+const taskService = new TaskService({ store: taskRepository, defaultProjectId: getDefaultProjectId });
 
 /** 读取所有任务（含运行时归一化） */
 function loadTasks(): Task[] {
   return taskRepository.read();
-}
-
-function artifactId(url: string): string {
-  let hash = 5381;
-  for (let index = 0; index < url.length; index++) hash = ((hash << 5) + hash) ^ url.charCodeAt(index);
-  return `artifact-${(hash >>> 0).toString(16)}`;
-}
-
-function appendArtifacts(task: Task, outputs: string[], source: TaskArtifact['source'] = 'network'): void {
-  const existing = new Map((task.artifacts || []).map((artifact) => [artifact.url, artifact]));
-  for (const url of outputs) {
-    if (!url || existing.has(url)) continue;
-    const artifact: TaskArtifact = {
-      id: artifactId(url),
-      url,
-      kind: task.mode === 'video' ? 'video' : task.mode === 'image' ? 'image' : 'file',
-      source,
-      runId: task.runtime?.runId,
-      conversationUrl: task.runtime?.conversationUrl,
-      discoveredAt: new Date().toISOString(),
-    };
-    existing.set(url, artifact);
-  }
-  task.artifacts = [...existing.values()];
 }
 
 import { parseCsv, normalizeCsvMode } from '../utils/csv';
@@ -244,40 +220,8 @@ export function registerTaskIPC(): () => void {
     'tasks:add',
     async (_event, params: TaskAddParams): Promise<{ success: boolean; tasks?: Task[]; error?: string }> => {
       try {
-        if (!params.prompts || params.prompts.length === 0) {
-          return { success: false, error: '请输入至少一条提示词' };
-        }
-
-        const tasks = loadTasks();
-        const mode: GenerationMode = params.mode || 'chat';
-        const newTasks: Task[] = params.prompts
-          .filter((p) => p.trim().length > 0)
-          .map((prompt) => ({
-            id: uuidv4(),
-            prompt: prompt.trim(),
-            assignedAccountId: null,
-            status: 'queued' as TaskStatus,
-            mode,
-            videoConfig: params.videoConfig,
-            attachments: params.attachments,
-            audioAttachment: params.audioAttachment,
-            result: null,
-            outputs: [],
-            artifacts: [],
-            runHistory: [],
-            source: 'manual',
-            dependsOnTaskIds: [],
-            projectId: params.projectId || getDefaultProjectId(),
-            errorInfo: undefined,
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-          }));
-
-        tasks.push(...newTasks);
-        const saved = saveTasksOrError(tasks);
-        if (!saved.success) return saved;
-
-        return { success: true, tasks: newTasks };
+        const result = taskService.create(params);
+        return result.success ? { success: true, tasks: result.data } : result;
       } catch (err: any) {
         return { success: false, error: err.message };
       }
@@ -313,23 +257,7 @@ export function registerTaskIPC(): () => void {
       _event,
       params: TaskUpdateStatusParams
     ): Promise<{ success: boolean; error?: string }> => {
-      const tasks = loadTasks();
-      const task = tasks.find((t) => t.id === params.taskId);
-      if (!task) {
-        return { success: false, error: '任务不存在' };
-      }
-
-      task.status = params.status;
-      if (params.result !== undefined) task.result = params.result;
-      if (params.outputs !== undefined) {
-        task.outputs = [...new Set(params.outputs.filter(Boolean))];
-        appendArtifacts(task, task.outputs);
-      }
-      if (params.status === 'done') task.errorInfo = undefined;
-      task.updatedAt = new Date().toISOString();
-      saveTasks(tasks);
-
-      return { success: true };
+      return taskService.updateStatus(params);
     }
   );
 
@@ -370,24 +298,7 @@ export function registerTaskIPC(): () => void {
   ipcMain.handle(
     'tasks:delete',
     async (_event, params: TaskIdParams): Promise<{ success: boolean; error?: string }> => {
-      const tasks = loadTasks();
-      const idx = tasks.findIndex((t) => t.id === params.taskId);
-      if (idx === -1) {
-        return { success: false, error: '任务不存在' };
-      }
-      const task = tasks[idx];
-      if (['executing', 'generating', 'waiting_verification'].includes(task.status)) {
-        return { success: false, error: '任务正在执行，请先暂停后再删除' };
-      }
-      const dependentCount = tasks.filter((item) => item.dependsOnTaskIds?.includes(task.id)).length;
-      if (dependentCount > 0) {
-        return { success: false, error: `仍有 ${dependentCount} 个任务依赖此任务，请先调整依赖关系` };
-      }
-
-      tasks.splice(idx, 1);
-      const saved = saveTasksOrError(tasks);
-      if (!saved.success) return saved;
-      return { success: true };
+      return taskService.delete(params.taskId);
     }
   );
 
@@ -395,20 +306,8 @@ export function registerTaskIPC(): () => void {
   ipcMain.handle(
     'tasks:retry',
     async (_event, params: TaskIdParams): Promise<{ success: boolean; task?: Task; error?: string }> => {
-      const tasks = loadTasks();
-      const task = tasks.find((t) => t.id === params.taskId);
-      if (!task) {
-        return { success: false, error: '任务不存在' };
-      }
-      if (task.status === 'executing' || task.status === 'generating' || task.status === 'waiting_verification') {
-        return { success: false, error: '任务正在执行中，无法重试' };
-      }
-
-      resetTaskForQueue(task);
-      const saved = saveTasksOrError(tasks);
-      if (!saved.success) return saved;
-
-      return { success: true, task };
+      const result = taskService.retry(params.taskId);
+      return result.success ? { success: true, task: result.data } : result;
     }
   );
 

--- a/tests/unit/taskService.test.ts
+++ b/tests/unit/taskService.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type { Task } from '@doubao-studio/contracts';
+import { TaskService } from '../../main/core/TaskService';
+
+function base(id: string, status: Task['status'] = 'queued'): Task {
+  return { id, prompt: id, assignedAccountId: null, status, mode: 'video', result: null, outputs: [], artifacts: [], createdAt: 'old', updatedAt: 'old' };
+}
+
+function fixture(initial: Task[] = []) {
+  let stored = structuredClone(initial);
+  const store = { read: () => structuredClone(stored), replace: (tasks: Task[]) => { stored = structuredClone(tasks); return true; } };
+  let id = 0;
+  const service = new TaskService({ store, defaultProjectId: () => 'default', id: () => `id-${++id}`, now: () => 'now' });
+  return { service, stored: () => stored };
+}
+
+describe('TaskService 核心用例', () => {
+  it('过滤空提示词并创建规范任务', () => {
+    const { service, stored } = fixture();
+    const result = service.create({ prompts: [' A ', ' ', 'B'], mode: 'video' });
+    expect(result.success && result.data.map((task) => task.prompt)).toEqual(['A', 'B']);
+    expect(stored().map((task) => [task.id, task.projectId, task.status])).toEqual([['id-1', 'default', 'queued'], ['id-2', 'default', 'queued']]);
+  });
+
+  it('空输入 fail-closed 且不写入', () => {
+    const { service, stored } = fixture();
+    expect(service.create({ prompts: [' '] })).toEqual({ success: false, error: '请输入至少一条提示词' });
+    expect(stored()).toEqual([]);
+  });
+
+  it('状态更新去重产物并清除成功任务错误', () => {
+    const item = base('t1', 'fail'); item.errorInfo = { code: 'timeout', message: 'x', recoverable: true, detectedAt: 'old' };
+    const { service, stored } = fixture([item]);
+    expect(service.updateStatus({ taskId: 't1', status: 'done', outputs: ['u', 'u'] }).success).toBe(true);
+    expect(stored()[0].outputs).toEqual(['u']); expect(stored()[0].artifacts).toHaveLength(1); expect(stored()[0].errorInfo).toBeUndefined();
+  });
+
+  it('执行中或存在下游依赖时禁止删除', () => {
+    expect(fixture([base('t1', 'executing')]).service.delete('t1').success).toBe(false);
+    const child = base('child'); child.dependsOnTaskIds = ['t1'];
+    expect(fixture([base('t1'), child]).service.delete('t1')).toEqual({ success: false, error: '仍有 1 个任务依赖此任务，请先调整依赖关系' });
+  });
+
+  it('安全删除无依赖的非活动任务', () => {
+    const { service, stored } = fixture([base('t1', 'done')]);
+    expect(service.delete('t1')).toEqual({ success: true }); expect(stored()).toEqual([]);
+  });
+
+  it('重试清除结果、输出、错误和锁并恢复运行阶段', () => {
+    const item = base('t1', 'fail'); item.result = 'x'; item.outputs = ['u']; item.lock = { ownerId: 'o', acquiredAt: 'old', expiresAt: 'old' };
+    item.errorInfo = { code: 'timeout', message: 'x', recoverable: true, detectedAt: 'old' };
+    item.runtime = { runId: 'r', attempt: 1, stage: 'failed', message: 'x', startedAt: 'old', stageStartedAt: 'old', lastHeartbeatAt: 'old', input: { prompt: 't1', mode: 'video', attachments: [] } };
+    const { service, stored } = fixture([item]);
+    expect(service.retry('t1').success).toBe(true);
+    expect(stored()[0]).toMatchObject({ status: 'queued', result: null, outputs: [], updatedAt: 'now', runtime: { stage: 'queued', message: '等待执行' } });
+    expect(stored()[0].lock).toBeUndefined(); expect(stored()[0].errorInfo).toBeUndefined();
+  });
+
+  it('Repository 冲突或写盘异常统一返回安全失败', () => {
+    const service = new TaskService({
+      store: { read: () => [], replace: () => { throw new Error('TASK_REPOSITORY_STALE_SNAPSHOT'); } },
+      defaultProjectId: () => 'default', id: () => 'id', now: () => 'now',
+    });
+    expect(service.create({ prompts: ['A'] })).toEqual({
+      success: false, error: '任务数据写入失败，请检查磁盘空间和数据目录权限',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extract create, status/artifact update, delete and retry into TaskService
- keep TaskRepository as the only tasks.json writer
- map persistence conflicts to fail-closed IPC results
- preserve current IPC contracts and UI behavior

## Validation
- full validate PASS
- 22 files / 526 tests PASS
- TypeScript and production build PASS

No CLI/MCP/HTTP, deployment, real generation, or production data changes.