### PR TITLE
refactor(core): move task assignment editing and pause into service

### DIFF
--- a/docs/handoffs/2026-08-13-doubao-core-task-service-02.md
+++ b/docs/handoffs/2026-08-13-doubao-core-task-service-02.md
@@ -1,0 +1,228 @@
+# DOUBAO-CORE-TASK-SERVICE-02 检查报告
+
+## 已读取的治理文件
+
+- `D:\项目架构师\memory\INDEX.md`
+- `D:\项目架构师\DEVELOPMENT_EFFICIENCY_GOVERNANCE.md`
+- `D:\豆包工作室\doubao-core-task-service-02\AGENTS.md`
+- `README.md`
+- `ROADMAP.md`
+- `DESIGN.md`
+- `AGENT_EXECUTION_PLAN.md`
+- `docs/handoffs/2026-08-13-doubao-core-repository-events-01.md`
+- `docs/handoffs/2026-08-13-doubao-core-task-service-01.md`
+- `main/core/TaskRepository.ts`
+- `main/core/TaskEventStream.ts`
+- `main/core/TaskService.ts`
+- `main/ipc/tasks.ts`
+- `tests/unit/taskService.test.ts`
+- `packages/contracts/src/dto/tasks.ts`（TaskAssignParams、TaskUpdateInput、TaskUpdateParams）
+- `packages/contracts/src/domain.ts`（Task、TaskErrorInfo、TaskRunSnapshot）
+- `packages/contracts/src/enums.ts`（TaskStatus、TaskStage）
+- `packages/contracts/src/dto/electron-api.ts`（ElectronAPI preload 契约）
+
+## 工作树、分支、基线 HEAD 和最终未提交状态
+
+- 工作树：`D:\豆包工作室\doubao-core-task-service-02`
+- 分支：`glm/doubao-core-task-service-02`
+- 基线 HEAD：`9915e8c583e0d3fe317b965be6f59e6ad5a67649`
+- 最终 HEAD（未提交）：`9915e8c583e0d3fe317b965be6f59e6ad5a67649`（无新提交）
+- tracked 修改：
+  - `main/core/TaskService.ts`（M）
+  - `main/ipc/tasks.ts`（M）
+  - `tests/unit/taskService.test.ts`（M）
+- untracked 新增：
+  - `docs/handoffs/2026-08-13-doubao-core-task-service-02.md`（本文件）
+- 无其他 tracked/untracked 改动
+- 未进入或修改 `D:\豆包工作室\doubao-studio-main`
+
+## 冻结验收包三个 P0 的逐项结果
+
+### P0-1：账号指派与任务编辑进入 TaskService — 完成
+
+**新增 TaskService 方法：**
+
+- `assign(params: TaskAssignParams): TaskServiceResult`
+  - 找不到任务返回 `'任务不存在'`
+  - `executing`、`generating`、`waiting_verification` 状态禁止重新指派，返回 `'任务正在自动化执行中，无法重新指派'`
+  - 成功后更新 `assignedAccountId`
+  - 成功后通过 `resetTaskForQueue` 执行与现有语义完全一致的重置（status→queued, result→null, outputs→[], errorInfo→undefined, lock→undefined, runtime stage→queued/message→等待执行/stageStartedAt+lastHeartbeatAt→timestamp, updatedAt→timestamp）
+  - Repository `replace` 返回 false 或抛出陈旧快照异常时 fail-closed，返回 `'任务数据写入失败，请检查磁盘空间和数据目录权限'`
+
+- `update(params: { taskId: string; updates: TaskUpdateInput }): TaskServiceResult<Task>`
+  - 找不到任务返回 `'任务不存在'`
+  - prompt trim 后为空返回 `'提示词不能为空'`
+  - 正确更新 prompt（trim 后）、videoConfig、attachments、audioAttachment
+  - 空 attachments 规范为 `undefined`
+  - 空 audioAttachment 规范为 `undefined`
+  - 成功后通过 `resetTaskForQueue` 执行重置
+  - Repository `replace` 返回 false 或抛出陈旧快照异常时 fail-closed
+
+**新增私有方法：**
+
+- `resetTaskForQueue(task: Task, timestamp: string): void` — 将原 IPC 层的 `resetTaskForQueue` 业务语义移入 Core 边界，使用注入的 `now()` 作为唯一时间源，同一次操作时间值一致
+- `readTasks(): Task[] | null` — 捕获 `store.read()` 异常，防止 read 抛错形成未处理异常
+
+**retry 方法重构：** 复用 `resetTaskForQueue`，消除重复逻辑
+
+### P0-2：批量暂停进入 TaskService — 完成
+
+- `batchPause(): TaskServiceResult`
+  - 只处理 `executing`、`generating`、`waiting_verification` 三种活动状态
+  - 其他状态保持原样
+  - 目标任务状态改为 `paused`
+  - `result` 设为 `'批量暂停'`
+  - `errorInfo` = `{ code: 'cancelled', message: '批量暂停', recoverable: true, detectedAt: timestamp }`
+  - 存在 runtime 时：`stage: 'paused'`, `message: '批量暂停'`, `stageStartedAt` 和 `lastHeartbeatAt` 使用同一注入时间
+  - `updatedAt` 使用同一注入时间
+  - 不改变 `runHistory`、`artifacts`、`outputs` 或其他无关字段
+  - Repository `replace` 返回 false 或抛出异常时 fail-closed
+  - 无活动任务时返回 `{ success: true }` 且不写回（最小兼容方案：避免无变更的冗余写入，外部行为与原实现一致返回 success=true）
+  - **修复虚假成功：** 原实现 `saveTasks(tasks)` 忽略返回值且可能抛出未处理异常；新实现通过 `persist` 捕获并 fail-closed
+
+### P0-3：IPC 退化为薄适配层并补行为测试 — 完成
+
+**三个 IPC handler 退化：**
+
+- `tasks:assign` — 只调用 `taskService.assign(params)` 并返回
+- `tasks:update` — 只调用 `taskService.update(params)` 并映射 `result.data` 为 `task`
+- `tasks:batchPause` — 只调用 `taskService.batchPause()` 并提取 `result.success`
+
+**channel 名称、preload API、DTO、UI 不变。**
+
+**删除死代码：**
+- `resetTaskForQueue` 函数（原 IPC 层重复实现，已由 TaskService.resetTaskForQueue 替代）
+- `saveTasksOrError` 函数（已由 TaskService.persist 替代）
+
+**IPC 不再包含三项业务状态变换的重复实现**（经源码检查确认，`resetTaskForQueue` 和 `saveTasksOrError` 已从 tasks.ts 完全删除，grep 零匹配）
+
+## 精确修改文件清单
+
+| 类型 | 文件 | 说明 |
+| --- | --- | --- |
+| tracked 修改 | `main/core/TaskService.ts` | 新增 assign、update、batchPause 方法；新增 resetTaskForQueue、readTasks 私有方法；重构 retry 复用 resetTaskForQueue；引入 WRITE_ERROR 常量 |
+| tracked 修改 | `main/ipc/tasks.ts` | 三个 handler 退化为薄适配层；删除 resetTaskForQueue 和 saveTasksOrError 死代码 |
+| tracked 修改 | `tests/unit/taskService.test.ts` | 新增 19 项行为测试（assign 5 + update 4 + batchPause 4 + fail-closed 6） |
+| untracked 新增 | `docs/handoffs/2026-08-13-doubao-core-task-service-02.md` | 本交接报告 |
+
+文件预算 4 个，实际 4 个，未超出。
+
+## 账号指派、任务编辑、批量暂停的新旧调用边界
+
+### tasks:assign
+
+| 项 | 旧（IPC 内联） | 新（TaskService） |
+| --- | --- | --- |
+| 入口 | `loadTasks()` + 内联查找 | `readTasks()` + 内联查找 |
+| 活动状态判断 | `task.status === 'executing' \|\| ...` | `ACTIVE.has(task.status)` |
+| 重置 | IPC 层 `resetTaskForQueue(task)` 用 `new Date()` | Core `this.resetTaskForQueue(task, this.now())` |
+| 持久化 | `saveTasksOrError(tasks)` 不捕获 replace 异常 | `this.persist(tasks)` 捕获 replace 异常 |
+| read 异常 | 不处理，形成未处理 rejection | `readTasks()` 捕获，返回安全错误 |
+
+### tasks:update
+
+| 项 | 旧（IPC 内联） | 新（TaskService） |
+| --- | --- | --- |
+| 入口 | `loadTasks()` + 内联查找 | `readTasks()` + 内联查找 |
+| prompt 校验 | IPC 内联 | Core 内联 |
+| 字段规范化 | IPC 内联 | Core 内联 |
+| 重置 | IPC 层 `resetTaskForQueue(task)` | Core `this.resetTaskForQueue(task, this.now())` |
+| 持久化 | `saveTasksOrError(tasks)` | `this.persist(tasks)` |
+
+### tasks:batchPause
+
+| 项 | 旧（IPC 内联） | 新（TaskService） |
+| --- | --- | --- |
+| 入口 | `loadTasks()` | `readTasks()` |
+| 活动状态判断 | 内联 `task.status === ...` | `ACTIVE.has(task.status)` |
+| 时间源 | 循环内 `new Date().toISOString()` 每次不同 | 单次 `this.now()` 全局一致 |
+| 持久化 | `saveTasks(tasks)` **忽略返回值** | `this.persist(tasks)` **检查返回值** |
+| 无活动任务 | 仍调用 `saveTasks` | 跳过写入，返回 success |
+
+## fail-closed 行为及写入失败证据
+
+| 用例 | replace=false | replace 抛出 STALE_SNAPSHOT |
+| --- | --- | --- |
+| assign | `{ success: false, error: WRITE_ERROR }` | `{ success: false, error: WRITE_ERROR }` |
+| update | `{ success: false, error: WRITE_ERROR }` | `{ success: false, error: WRITE_ERROR }` |
+| batchPause | `{ success: false, error: WRITE_ERROR }` | `{ success: false, error: WRITE_ERROR }` |
+
+- `persist` 方法 `try/catch` 包裹 `store.replace`，异常统一返回 `false`
+- `readTasks` 方法 `try/catch` 包裹 `store.read`，异常统一返回 `null` → 调用方返回 `WRITE_ERROR`
+- 原实现中 `batchPause` 调用 `saveTasks(tasks)` 忽略返回值——此虚假成功已修复
+- 原实现中 `saveTasksOrError` 不捕获 `replace` 抛出的陈旧快照异常——此未处理 rejection 已修复
+- 专项测试覆盖了上述 6 个 fail-closed 场景
+
+## 新增专项测试数量和逐级门禁结果
+
+### 新增测试
+
+| 分组 | 浽数 | 覆盖项 |
+| --- | --- | --- |
+| assign | 5（含 it.each × 3 状态） | 成功+完整 reset、三种活动状态禁止、目标不存在 |
+| update | 4 | 成功+字段规范化、空 prompt 拒绝、空 attachments→undefined、空 audioAttachment→undefined |
+| batchPause | 4 | 只影响三种活动状态、时间一致性、无关字段不变、无活动任务不写入 |
+| fail-closed | 6 | assign/update/batchPause × replace=false / stale snapshot |
+| **合计** | **19** | 不超过 30 项 |
+
+### 日常开发门禁
+
+| 门禁 | 结果 |
+| --- | --- |
+| `pnpm.cmd exec vitest run tests/unit/taskService.test.ts` | 26 pass / 0 fail（7 原有 + 19 新增） |
+| `pnpm.cmd exec eslint main/core/TaskService.ts main/ipc/tasks.ts tests/unit/taskService.test.ts` | 0 error / 20 warning（全部为 tasks.ts 既有 warning，非本次引入） |
+| `git diff --check` | PASS（无空白错误） |
+
+### 候选验收门禁
+
+| 门禁 | 结果 |
+| --- | --- |
+| `pnpm.cmd run validate` | **PASS**（exit code 0） |
+| TypeScript | 0 error |
+| ESLint | 0 error / 142 warning（低于 149 冻结上限） |
+| check:project（IPC/contracts 边界） | PASS |
+| 全量测试 | 22 files / 546 pass / 0 fail |
+| Renderer 构建 | PASS（Vite 6.4.3，3057 modules） |
+| Main 构建 | PASS（tsc 编译成功） |
+
+## git diff --check 结果
+
+PASS — 无空白错误，exit code 0。
+
+## 受保护资产零修改证明
+
+- 未修改 `packages/contracts/`（contracts 类型、DTO、preload API）
+- 未修改 `main/preload.ts`
+- 未修改 `src/`（renderer store、UI 组件）
+- 未修改 `main/core/TaskRepository.ts`（仍是 tasks.json 唯一写入边界）
+- 未修改 `main/core/TaskEventStream.ts`
+- 未修改 `scripts/`、配置文件、`package.json`、`pnpm-lock.yaml`
+- 未触碰 Cookie、Token、账号数据、用户素材、运行数据或 `.env`
+- 未进入或修改 `D:\豆包工作室\doubao-studio-main`
+- TaskRepository 仍是唯一 tasks.json 写边界（无直接 `writeJSON('tasks.json', ...)`）
+
+## 未处理事项与残余风险
+
+1. **现有方法（create、updateStatus、delete）仍直接调用 `this.deps.store.read()` 而非 `readTasks()`**——这些方法在上一开发包（TASK-SERVICE-01）迁移时未包含 read 异常捕获。本轮未对这些方法做超出范围的重构。如后续需要统一，可在下一开发包处理。
+
+2. **`tasks:batchPause` 的返回类型为 `{ success: boolean }`，不含 error 字段**——当写入失败时，IPC 层只能返回 `{ success: false }` 无法传递错误原因。这是 preload API 契约限制，本轮未修改 DTO。
+
+3. **`recoverInterruptedTasks` 函数仍使用 `saveTasks(tasks)` 且不检查返回值**——该函数不属于本轮三个 P0 目标，未做修改。
+
+4. **CLI/MCP/HTTP 仍未实现**——本包只迁移 Core 业务逻辑，未引入外部接口。
+
+## 单一裁决
+
+**PASS**
+
+三个 P0 全部完成；实际修改文件全部位于 4 文件 allowlist；TaskRepository 仍是唯一 tasks.json 写边界；IPC channel、DTO 和 UI 未改变；写入失败不再产生虚假成功；专项 26 pass / 0 fail；完整 validate PASS（546 pass / 0 fail）；受保护资产零修改；无未解决的当前阶段 P0。
+
+## 声明
+
+- 未暂存
+- 未提交
+- 未推送
+- 未创建或修改 PR
+- 未部署
+- 未启动或重启豆包工作室
+- 未触碰运行目录及凭据

--- a/main/core/TaskService.ts
+++ b/main/core/TaskService.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import type { GenerationMode, Task, TaskAddParams, TaskUpdateStatusParams } from '@doubao-studio/contracts';
+import type { GenerationMode, Task, TaskAddParams, TaskAssignParams, TaskUpdateStatusParams, TaskUpdateInput } from '@doubao-studio/contracts';
 
 export interface TaskStore {
   read(): Task[];
@@ -18,6 +18,7 @@ export type TaskServiceResult<T = undefined> =
   | { success: false; error: string };
 
 const ACTIVE = new Set<Task['status']>(['executing', 'generating', 'waiting_verification']);
+const WRITE_ERROR = '任务数据写入失败，请检查磁盘空间和数据目录权限';
 
 function artifactId(url: string): string {
   let hash = 5381;
@@ -34,12 +35,40 @@ export class TaskService {
     this.now = deps.now || (() => new Date().toISOString());
   }
 
+  private readTasks(): Task[] | null {
+    try {
+      return this.deps.store.read();
+    } catch {
+      return null;
+    }
+  }
+
   private persist(tasks: Task[]): boolean {
     try {
       return this.deps.store.replace(tasks);
     } catch {
       return false;
     }
+  }
+
+  /** 将任务重置为排队状态，清除运行结果、产物列表、错误信息和锁 */
+  private resetTaskForQueue(task: Task, timestamp: string): void {
+    task.status = 'queued';
+    task.result = null;
+    task.outputs = [];
+    task.errorInfo = undefined;
+    // 暂停/中断任务重新入队时不应继承旧运行锁，否则恢复后会被当作仍在执行。
+    task.lock = undefined;
+    if (task.runtime) {
+      task.runtime = {
+        ...task.runtime,
+        stage: 'queued',
+        message: '等待执行',
+        stageStartedAt: timestamp,
+        lastHeartbeatAt: timestamp,
+      };
+    }
+    task.updatedAt = timestamp;
   }
 
   create(params: TaskAddParams): TaskServiceResult<Task[]> {
@@ -59,8 +88,36 @@ export class TaskService {
       };
     });
     tasks.push(...created);
-    if (!this.persist(tasks)) return { success: false, error: '任务数据写入失败，请检查磁盘空间和数据目录权限' };
+    if (!this.persist(tasks)) return { success: false, error: WRITE_ERROR };
     return { success: true, data: created };
+  }
+
+  assign(params: TaskAssignParams): TaskServiceResult {
+    const tasks = this.readTasks();
+    if (!tasks) return { success: false, error: WRITE_ERROR };
+    const task = tasks.find((item) => item.id === params.taskId);
+    if (!task) return { success: false, error: '任务不存在' };
+    if (ACTIVE.has(task.status)) return { success: false, error: '任务正在自动化执行中，无法重新指派' };
+    task.assignedAccountId = params.accountId;
+    this.resetTaskForQueue(task, this.now());
+    if (!this.persist(tasks)) return { success: false, error: WRITE_ERROR };
+    return { success: true };
+  }
+
+  update(params: { taskId: string; updates: TaskUpdateInput }): TaskServiceResult<Task> {
+    const tasks = this.readTasks();
+    if (!tasks) return { success: false, error: WRITE_ERROR };
+    const task = tasks.find((item) => item.id === params.taskId);
+    if (!task) return { success: false, error: '任务不存在' };
+    const prompt = params.updates?.prompt?.trim();
+    if (!prompt) return { success: false, error: '提示词不能为空' };
+    task.prompt = prompt;
+    task.videoConfig = params.updates.videoConfig;
+    task.attachments = params.updates.attachments?.length ? params.updates.attachments : undefined;
+    task.audioAttachment = params.updates.audioAttachment || undefined;
+    this.resetTaskForQueue(task, this.now());
+    if (!this.persist(tasks)) return { success: false, error: WRITE_ERROR };
+    return { success: true, data: task };
   }
 
   updateStatus(params: TaskUpdateStatusParams): TaskServiceResult {
@@ -84,7 +141,7 @@ export class TaskService {
     }
     if (params.status === 'done') task.errorInfo = undefined;
     task.updatedAt = this.now();
-    if (!this.persist(tasks)) return { success: false, error: '任务数据写入失败，请检查磁盘空间和数据目录权限' };
+    if (!this.persist(tasks)) return { success: false, error: WRITE_ERROR };
     return { success: true };
   }
 
@@ -96,7 +153,7 @@ export class TaskService {
     const dependentCount = tasks.filter((task) => task.dependsOnTaskIds?.includes(taskId)).length;
     if (dependentCount > 0) return { success: false, error: `仍有 ${dependentCount} 个任务依赖此任务，请先调整依赖关系` };
     tasks.splice(index, 1);
-    if (!this.persist(tasks)) return { success: false, error: '任务数据写入失败，请检查磁盘空间和数据目录权限' };
+    if (!this.persist(tasks)) return { success: false, error: WRITE_ERROR };
     return { success: true };
   }
 
@@ -105,11 +162,30 @@ export class TaskService {
     const task = tasks.find((item) => item.id === taskId);
     if (!task) return { success: false, error: '任务不存在' };
     if (ACTIVE.has(task.status)) return { success: false, error: '任务正在执行中，无法重试' };
-    const timestamp = this.now();
-    task.status = 'queued'; task.result = null; task.outputs = []; task.errorInfo = undefined; task.lock = undefined;
-    if (task.runtime) task.runtime = { ...task.runtime, stage: 'queued', message: '等待执行', stageStartedAt: timestamp, lastHeartbeatAt: timestamp };
-    task.updatedAt = timestamp;
-    if (!this.persist(tasks)) return { success: false, error: '任务数据写入失败，请检查磁盘空间和数据目录权限' };
+    this.resetTaskForQueue(task, this.now());
+    if (!this.persist(tasks)) return { success: false, error: WRITE_ERROR };
     return { success: true, data: task };
+  }
+
+  batchPause(): TaskServiceResult {
+    const tasks = this.readTasks();
+    if (!tasks) return { success: false, error: WRITE_ERROR };
+    const timestamp = this.now();
+    let changed = false;
+    for (const task of tasks) {
+      if (ACTIVE.has(task.status)) {
+        task.status = 'paused';
+        task.result = '批量暂停';
+        task.errorInfo = { code: 'cancelled', message: '批量暂停', recoverable: true, detectedAt: timestamp };
+        if (task.runtime) {
+          task.runtime = { ...task.runtime, stage: 'paused', message: '批量暂停', stageStartedAt: timestamp, lastHeartbeatAt: timestamp };
+        }
+        task.updatedAt = timestamp;
+        changed = true;
+      }
+    }
+    if (!changed) return { success: true };
+    if (!this.persist(tasks)) return { success: false, error: WRITE_ERROR };
+    return { success: true };
   }
 }

--- a/main/ipc/tasks.ts
+++ b/main/ipc/tasks.ts
@@ -84,12 +84,6 @@ function saveTasks(tasks: Task[]): boolean {
   return taskRepository.replace(tasks);
 }
 
-function saveTasksOrError(tasks: Task[]): { success: true } | { success: false; error: string } {
-  return saveTasks(tasks)
-    ? { success: true }
-    : { success: false, error: '任务数据写入失败，请检查磁盘空间和数据目录权限' };
-}
-
 /** 读取下载记录（含运行时归一化 + 中断恢复） */
 function loadDownloadJobs(): DownloadJob[] {
   const raw = readJSON<unknown>(DOWNLOAD_STORE_FILE, []);
@@ -124,26 +118,6 @@ function getAvailableDownloadPath(fs: typeof import('fs'), path: typeof import('
     candidate = path.join(saveDir, `${parsed.name}-${suffix}${parsed.ext}`);
   }
   return candidate;
-}
-
-function resetTaskForQueue(task: Task): void {
-  task.status = 'queued';
-  task.result = null;
-  task.outputs = [];
-  task.errorInfo = undefined;
-  // 暂停/中断任务重新入队时不应继承旧运行锁，否则恢复后会被当作仍在执行。
-  task.lock = undefined;
-  if (task.runtime) {
-    const now = new Date().toISOString();
-    task.runtime = {
-      ...task.runtime,
-      stage: 'queued',
-      message: '等待执行',
-      stageStartedAt: now,
-      lastHeartbeatAt: now,
-    };
-  }
-  task.updatedAt = new Date().toISOString();
 }
 
 function recoverInterruptedTasks(): void {
@@ -232,21 +206,7 @@ export function registerTaskIPC(): () => void {
   ipcMain.handle(
     'tasks:assign',
     async (_event, params: TaskAssignParams): Promise<{ success: boolean; error?: string }> => {
-      const tasks = loadTasks();
-      const task = tasks.find((t) => t.id === params.taskId);
-      if (!task) {
-        return { success: false, error: '任务不存在' };
-      }
-      if (task.status === 'executing' || task.status === 'generating' || task.status === 'waiting_verification') {
-        return { success: false, error: '任务正在自动化执行中，无法重新指派' };
-      }
-
-      task.assignedAccountId = params.accountId;
-      resetTaskForQueue(task);
-      const saved = saveTasksOrError(tasks);
-      if (!saved.success) return saved;
-
-      return { success: true };
+      return taskService.assign(params);
     }
   );
 
@@ -271,26 +231,8 @@ export function registerTaskIPC(): () => void {
         updates: TaskUpdateInput;
       }
     ): Promise<{ success: boolean; task?: Task; error?: string }> => {
-      const tasks = loadTasks();
-      const task = tasks.find((t) => t.id === params.taskId);
-      if (!task) {
-        return { success: false, error: '任务不存在' };
-      }
-
-      const prompt = params.updates?.prompt?.trim();
-      if (!prompt) {
-        return { success: false, error: '提示词不能为空' };
-      }
-
-      task.prompt = prompt;
-      task.videoConfig = params.updates.videoConfig;
-      task.attachments = params.updates.attachments?.length ? params.updates.attachments : undefined;
-      task.audioAttachment = params.updates.audioAttachment || undefined;
-      resetTaskForQueue(task);
-      const saved = saveTasksOrError(tasks);
-      if (!saved.success) return saved;
-
-      return { success: true, task };
+      const result = taskService.update(params);
+      return result.success ? { success: true, task: result.data } : result;
     }
   );
 
@@ -315,21 +257,8 @@ export function registerTaskIPC(): () => void {
   ipcMain.handle(
     'tasks:batchPause',
     async (): Promise<{ success: boolean }> => {
-      const tasks = loadTasks();
-      for (const task of tasks) {
-        if (task.status === 'executing' || task.status === 'generating' || task.status === 'waiting_verification') {
-          const now = new Date().toISOString();
-          task.status = 'paused';
-          task.result = '批量暂停';
-          task.errorInfo = { code: 'cancelled', message: '批量暂停', recoverable: true, detectedAt: now };
-          if (task.runtime) {
-            task.runtime = { ...task.runtime, stage: 'paused', message: '批量暂停', stageStartedAt: now, lastHeartbeatAt: now };
-          }
-          task.updatedAt = now;
-        }
-      }
-      saveTasks(tasks);
-      return { success: true };
+      const result = taskService.batchPause();
+      return { success: result.success };
     }
   );
 

--- a/tests/unit/taskService.test.ts
+++ b/tests/unit/taskService.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { Task } from '@doubao-studio/contracts';
+import type { Task, TaskStage } from '@doubao-studio/contracts';
 import { TaskService } from '../../main/core/TaskService';
 
 function base(id: string, status: Task['status'] = 'queued'): Task {
@@ -64,5 +64,231 @@ describe('TaskService 核心用例', () => {
     expect(service.create({ prompts: ['A'] })).toEqual({
       success: false, error: '任务数据写入失败，请检查磁盘空间和数据目录权限',
     });
+  });
+});
+
+// ==================== assign ====================
+
+function withRuntime(task: Task, stage: TaskStage = 'queued'): Task {
+  task.runtime = {
+    runId: 'r', attempt: 1, stage, message: 'x', startedAt: 'old',
+    stageStartedAt: 'old', lastHeartbeatAt: 'old',
+    input: { prompt: task.prompt, mode: task.mode, attachments: [] },
+  };
+  return task;
+}
+
+describe('TaskService assign', () => {
+  it('指派成功并完整重置队列状态', () => {
+    const item = withRuntime(base('t1', 'paused'), 'paused');
+    item.result = 'old';
+    item.outputs = ['old'];
+    item.errorInfo = { code: 'timeout', message: 'x', recoverable: true, detectedAt: 'old' };
+    item.lock = { ownerId: 'o', acquiredAt: 'old', expiresAt: 'old' };
+    const { service, stored } = fixture([item]);
+    expect(service.assign({ taskId: 't1', accountId: 'acc-1' })).toEqual({ success: true });
+    const task = stored()[0];
+    expect(task.assignedAccountId).toBe('acc-1');
+    expect(task.status).toBe('queued');
+    expect(task.result).toBeNull();
+    expect(task.outputs).toEqual([]);
+    expect(task.errorInfo).toBeUndefined();
+    expect(task.lock).toBeUndefined();
+    expect(task.runtime?.stage).toBe('queued');
+    expect(task.runtime?.message).toBe('等待执行');
+    expect(task.runtime?.stageStartedAt).toBe('now');
+    expect(task.runtime?.lastHeartbeatAt).toBe('now');
+    expect(task.updatedAt).toBe('now');
+  });
+
+  it.each(['executing', 'generating', 'waiting_verification'] as const)(
+    '活动状态 %s 禁止指派且零写入',
+    (status) => {
+      const { service, stored } = fixture([base('t1', status)]);
+      expect(service.assign({ taskId: 't1', accountId: 'acc' })).toEqual({
+        success: false, error: '任务正在自动化执行中，无法重新指派',
+      });
+      expect(stored()[0].assignedAccountId).toBeNull();
+      expect(stored()[0].status).toBe(status);
+    },
+  );
+
+  it('指派目标不存在', () => {
+    const { service, stored } = fixture([base('t1')]);
+    expect(service.assign({ taskId: 'missing', accountId: 'acc' })).toEqual({
+      success: false, error: '任务不存在',
+    });
+    expect(stored()).toHaveLength(1);
+  });
+});
+
+// ==================== update ====================
+
+describe('TaskService update', () => {
+  it('编辑成功并规范化字段', () => {
+    const item = withRuntime(base('t1', 'fail'), 'failed');
+    const { service, stored } = fixture([item]);
+    const result = service.update({
+      taskId: 't1',
+      updates: { prompt: '  new  ', videoConfig: { model: 'seedance-2.0', duration: '10s', aspectRatio: '16:9' }, attachments: ['a.jpg'], audioAttachment: 'b.mp3' },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.prompt).toBe('new');
+      expect(result.data.videoConfig).toEqual({ model: 'seedance-2.0', duration: '10s', aspectRatio: '16:9' });
+      expect(result.data.attachments).toEqual(['a.jpg']);
+      expect(result.data.audioAttachment).toBe('b.mp3');
+    }
+    const task = stored()[0];
+    expect(task.prompt).toBe('new');
+    expect(task.status).toBe('queued');
+    expect(task.runtime?.stage).toBe('queued');
+    expect(task.updatedAt).toBe('now');
+  });
+
+  it('空提示词拒绝且零写入', () => {
+    const { service, stored } = fixture([base('t1', 'queued')]);
+    expect(service.update({ taskId: 't1', updates: { prompt: '  ' } })).toEqual({
+      success: false, error: '提示词不能为空',
+    });
+    expect(stored()[0].prompt).toBe('t1');
+  });
+
+  it('空 attachments 规范为 undefined', () => {
+    const { service, stored } = fixture([base('t1')]);
+    service.update({ taskId: 't1', updates: { prompt: 'new', attachments: [] } });
+    expect(stored()[0].attachments).toBeUndefined();
+  });
+
+  it('空 audioAttachment 规范为 undefined', () => {
+    const { service, stored } = fixture([base('t1')]);
+    service.update({ taskId: 't1', updates: { prompt: 'new', audioAttachment: '' } });
+    expect(stored()[0].audioAttachment).toBeUndefined();
+  });
+});
+
+// ==================== batchPause ====================
+
+describe('TaskService batchPause', () => {
+  it('只暂停活动状态，其他状态保持不变', () => {
+    const tasks: Task[] = [
+      ...(['executing', 'generating', 'waiting_verification'] as const).map((s, i) => withRuntime(base(`a${i}`, s), 'generating')),
+      ...(['queued', 'paused', 'done', 'fail', 'cancelled'] as const).map((s, i) => base(`i${i}`, s)),
+    ];
+    const { service, stored } = fixture(tasks);
+    expect(service.batchPause().success).toBe(true);
+    const result = stored();
+    expect(result[0].status).toBe('paused');
+    expect(result[1].status).toBe('paused');
+    expect(result[2].status).toBe('paused');
+    expect(result[3].status).toBe('queued');
+    expect(result[4].status).toBe('paused');
+    expect(result[5].status).toBe('done');
+    expect(result[6].status).toBe('fail');
+    expect(result[7].status).toBe('cancelled');
+  });
+
+  it('runtime、errorInfo 和 updatedAt 使用同一注入时间', () => {
+    const item = withRuntime(base('t1', 'executing'), 'generating');
+    const { service, stored } = fixture([item]);
+    service.batchPause();
+    const task = stored()[0];
+    expect(task.errorInfo).toEqual({ code: 'cancelled', message: '批量暂停', recoverable: true, detectedAt: 'now' });
+    expect(task.runtime?.stage).toBe('paused');
+    expect(task.runtime?.message).toBe('批量暂停');
+    expect(task.runtime?.stageStartedAt).toBe('now');
+    expect(task.runtime?.lastHeartbeatAt).toBe('now');
+    expect(task.updatedAt).toBe('now');
+    expect(task.result).toBe('批量暂停');
+  });
+
+  it('无关字段保持不变', () => {
+    const item = withRuntime(base('t1', 'executing'), 'generating');
+    item.runHistory = [{ runId: 'r', attempt: 1, startedAt: 'old' }];
+    item.artifacts = [{ id: 'a1', url: 'http://x', kind: 'video', source: 'network', discoveredAt: 'old' }];
+    item.outputs = ['old-output'];
+    item.batchId = 'batch-1';
+    item.source = 'csv';
+    item.dependsOnTaskIds = ['dep-1'];
+    const { service, stored } = fixture([item]);
+    service.batchPause();
+    const task = stored()[0];
+    expect(task.runHistory).toEqual([{ runId: 'r', attempt: 1, startedAt: 'old' }]);
+    expect(task.artifacts).toEqual([{ id: 'a1', url: 'http://x', kind: 'video', source: 'network', discoveredAt: 'old' }]);
+    expect(task.outputs).toEqual(['old-output']);
+    expect(task.batchId).toBe('batch-1');
+    expect(task.source).toBe('csv');
+    expect(task.dependsOnTaskIds).toEqual(['dep-1']);
+    expect(task.runtime?.runId).toBe('r');
+    expect(task.runtime?.attempt).toBe(1);
+    expect(task.runtime?.startedAt).toBe('old');
+    expect(task.runtime?.input).toEqual({ prompt: 't1', mode: 'video', attachments: [] });
+  });
+
+  it('无活动任务时返回成功且不写入', () => {
+    const initial = [base('t1', 'queued'), base('t2', 'done')];
+    let stored = structuredClone(initial);
+    let writeCount = 0;
+    const store = {
+      read: () => structuredClone(stored),
+      replace: (t: Task[]) => { writeCount++; stored = structuredClone(t); return true; },
+    };
+    const service = new TaskService({ store, defaultProjectId: () => 'default', now: () => 'now' });
+    expect(service.batchPause()).toEqual({ success: true });
+    expect(writeCount).toBe(0);
+  });
+});
+
+// ==================== fail-closed ====================
+
+describe('TaskService fail-closed', () => {
+  const WRITE_ERROR = '任务数据写入失败，请检查磁盘空间和数据目录权限';
+
+  it('assign 在 Repository replace=false 时 fail-closed', () => {
+    const service = new TaskService({
+      store: { read: () => [structuredClone(base('t1', 'queued'))], replace: () => false },
+      defaultProjectId: () => 'default', now: () => 'now',
+    });
+    expect(service.assign({ taskId: 't1', accountId: 'acc' })).toEqual({ success: false, error: WRITE_ERROR });
+  });
+
+  it('assign 在 Repository 抛出陈旧快照异常时 fail-closed', () => {
+    const service = new TaskService({
+      store: { read: () => [structuredClone(base('t1', 'queued'))], replace: () => { throw new Error('TASK_REPOSITORY_STALE_SNAPSHOT'); } },
+      defaultProjectId: () => 'default', now: () => 'now',
+    });
+    expect(service.assign({ taskId: 't1', accountId: 'acc' })).toEqual({ success: false, error: WRITE_ERROR });
+  });
+
+  it('update 在 Repository replace=false 时 fail-closed', () => {
+    const service = new TaskService({
+      store: { read: () => [structuredClone(base('t1', 'queued'))], replace: () => false },
+      defaultProjectId: () => 'default', now: () => 'now',
+    });
+    expect(service.update({ taskId: 't1', updates: { prompt: 'new' } })).toEqual({ success: false, error: WRITE_ERROR });
+  });
+
+  it('update 在 Repository 抛出陈旧快照异常时 fail-closed', () => {
+    const service = new TaskService({
+      store: { read: () => [structuredClone(base('t1', 'queued'))], replace: () => { throw new Error('TASK_REPOSITORY_STALE_SNAPSHOT'); } },
+      defaultProjectId: () => 'default', now: () => 'now',
+    });
+    expect(service.update({ taskId: 't1', updates: { prompt: 'new' } })).toEqual({ success: false, error: WRITE_ERROR });
+  });
+
+  it('batchPause 在 Repository replace=false 时 fail-closed', () => {
+    const service = new TaskService({
+      store: { read: () => [structuredClone(base('t1', 'executing'))], replace: () => false },
+      defaultProjectId: () => 'default', now: () => 'now',
+    });
+    expect(service.batchPause()).toEqual({ success: false, error: WRITE_ERROR });
+  });
+
+  it('batchPause 在 Repository 抛出陈旧快照异常时 fail-closed', () => {
+    const service = new TaskService({
+      store: { read: () => [structuredClone(base('t1', 'executing'))], replace: () => { throw new Error('TASK_REPOSITORY_STALE_SNAPSHOT'); } },
+      defaultProjectId: () => 'default', now: () => 'now',
+    });
+    expect(service.batchPause()).toEqual({ success: false, error: WRITE_ERROR });
   });
 });


### PR DESCRIPTION
## 概要

- 将账号指派、任务编辑与批量暂停迁入 `TaskService`
- 保持 IPC channel、DTO、preload 与 UI 行为不变
- 统一 Repository 写入失败的 fail-closed 语义，修复批量暂停虚假成功

## 验证

- TaskService 专项：26/26 pass
- 完整 `pnpm run validate`：PASS
- 全量测试：546/546 pass
- ESLint：0 error / 142 个既有 warning
- `git diff --check`：PASS

## 边界

Draft 候选；未部署、未启动或重启豆包工作室，未触碰运行目录及凭据。