### PR TITLE
refactor(core): move artifact validation into TaskService

### DIFF
--- a/docs/handoffs/2026-08-13-doubao-core-task-validate-artifact-01.md
+++ b/docs/handoffs/2026-08-13-doubao-core-task-validate-artifact-01.md
@@ -1,0 +1,122 @@
+# DOUBAO-CORE-TASK-VALIDATE-ARTIFACT-01 冻结验收包
+
+- 状态：冻结定稿，待总架构师/用户确认后实施
+- 基线：`origin/main` `c9ea2f62ed8412607edda2d06fa55ce49f4625d0`（PR #16 merge，含 CSV 导入服务化）
+- 工作树：`D:\豆包工作室\doubao-core-task-validate-artifact-01`
+- 分支：`glm/doubao-core-task-validate-artifact-01`
+- 治理：`D:\项目架构师\DEVELOPMENT_EFFICIENCY_GOVERNANCE.md` 已读；单开发者自审 + 总架构师验收 + 用户逐项授权
+
+## 核心目标
+
+把 `tasks:validateArtifact` 的产物校验业务迁入 TaskService：Core 负责任务/产物查找、四态状态机（valid/expired/invalid/unknown）、单一时间源与 Repository fail-closed 持久化；IPC 仅保留 Electron 网络探针（session/partition）的注入与结果映射。顺带消除 `saveTasks` 忽略返回值的残余风险——本包完成后 `saveTasks` 无调用方，直接删除。
+
+## P0 清单
+
+### P0-1：Core `validateArtifact` 纯业务方法
+
+- 新增 `TaskService.validateArtifact(params: TaskValidateArtifactParams): Promise<TaskServiceResult<TaskValidateArtifactData>>`。
+- 查找任务与产物：任务或产物不存在 → `{ success: false, error: '产物不存在' }`，零探针/零时钟/零写入。
+- 探针依赖注入：`TaskServiceDependencies` 新增可选 `probeArtifact?: (artifact: TaskArtifact, assignedAccountId: string | null) => Promise<ArtifactProbeResult>`；未注入时返回 `{ success: false, error: '产物验证不可用' }`。Core 不依赖 Electron、session、partition 或 accounts.json。
+- 四态判定（保持现有语义）：
+  - `response` 且 statusCode 2xx（含 206）→ `valid`；401/403/404/410 → `expired`；其余 → `invalid`；`contentType`/`contentLength`/`statusCode` 落盘。
+  - `timeout` → `unknown` + `error: '验证超时'`。
+  - `error` → `invalid` + `error: message`。
+- 单一时间源：`this.now()` 单次调用，同时用于 `validation.checkedAt` 与 `task.updatedAt`。
+- 返回数据：`{ valid: state === 'valid', artifact }`；IPC 按既有 `TaskValidateArtifactResult` 形状映射（success/artifact/error）。
+
+### P0-2：Repository fail-closed 与残余风险消除
+
+- `readTasks()` 失败 → `WRITE_ERROR`，零探针/零时钟/零写入。
+- `persist()` 失败（返回 false 或抛出，含陈旧快照/未追踪快照）→ `WRITE_ERROR`，不返回 artifact、不返回成功。
+- `tasks.ts` 删除 `saveTasks` 函数（本包后无调用方）；`loadTasks` 保留（`tasks:list`、`tasks:getCompletedOutputs`、`tasks:exportDiagnostics` 仍使用）。
+
+### P0-3：IPC 薄适配与专项测试
+
+- `tasks:validateArtifact` handler 只保留：调用 `taskService.validateArtifact(params)`、结果形状映射、固定脱敏兜底错误 `'产物验证失败，请检查网络和数据目录状态'`（catch 不使用 `err.message`）。
+- 探针函数定义在 `tasks.ts`（IPC 边界）：accounts.json partition 解析、`session.fromPartition`、15s AbortController、`Referer`/`Range: bytes=0-0`、`response.body?.cancel()`；AbortError → `timeout`，其他异常 → `error`。
+- 新增专项测试 ≤30 块，优先 it.each 参数化；IPC 接线使用源码契约检查（符合既有允许方案）。
+
+## 允许修改文件（4 文件 allowlist）
+
+- `main/core/TaskService.ts`
+- `main/ipc/tasks.ts`
+- `tests/unit/taskService.test.ts`
+- `docs/handoffs/2026-08-13-doubao-core-task-validate-artifact-01.md`
+
+## 禁止触碰资产
+
+- `packages/contracts/`（类型、DTO、preload API、enums、domain 全部零修改）
+- `main/preload.ts`、`src/`（renderer）、`main/core/TaskRepository.ts`、`main/core/TaskEventStream.ts`、`main/utils/**`
+- 配置文件、`package.json`、`pnpm-lock.yaml`、`.github/**`、`scripts/`、`schemas/`
+- Cookie、Token、账号数据、运行数据、`.env`、`D:\豆包工作室\doubao-studio-main`
+
+## 行为保持与明确非目标
+
+- 四态判定语义与 IPC 返回形状不变；唯一行为变化：持久化失败由「静默忽略、仍可能返回 success」改为 fail-closed `WRITE_ERROR`。
+- 网络错误消息沿用 `err.message` 透传（现有行为；产物 URL 为 renderer 已知地址，非凭据）。
+- 不做自动重试、批量校验、只读查询、CLI/MCP/HTTP 接口。
+
+## 测试计划
+
+- 服务层（约 18–20 块，参数化优先）：四态判定（it.each×多状态码）、timeout、network error、任务/产物不存在零写入、read 失败零探针/零时钟/零写、replace=false 与陈旧快照 fail-closed、单一时间源、探针参数传递（artifact + assignedAccountId）、success 标志映射、未注入探针 fail-closed。
+- IPC 源码契约（2 块）：handler 不含四态业务实现且调用 `taskService.validateArtifact(`；`saveTasks` 已删除、脱敏兜底存在。
+
+## 门禁
+
+- 日常开发门禁：`pnpm.cmd exec vitest run tests/unit/taskService.test.ts tests/unit/taskRepository.test.ts`、修改文件 eslint、`git diff --check`。
+- 候选验收门禁：`pnpm.cmd run validate`（全量测试 + contracts 边界 + renderer/main 构建）。
+
+## 完成与停止条件
+
+- 三个 P0 全部满足；无未解决当前阶段 P0；适用门禁通过；受保护资产零修改；报告与 Git/测试事实一致。
+- 最多两轮整改（R1/R2）；R2 后未过则缩小范围或重开根因包，禁止 R3 链。
+- 不部署、不启动、不创建 Tag/Release；Git/PR/CI/合并按用户逐项授权执行。
+
+---
+
+# 实施记录（2026-08-13，同文件续写）
+
+## 最终 Git 状态（未提交）
+
+- tracked 修改：`main/core/TaskService.ts`（M）、`main/ipc/tasks.ts`（M）、`tests/unit/taskService.test.ts`（M）
+- untracked 新增：`docs/handoffs/2026-08-13-doubao-core-task-validate-artifact-01.md`（本文件）
+- 无其他改动；未进入或修改 `D:\豆包工作室\doubao-studio-main`
+
+## 实现要点
+
+- `TaskService` 新增：`TaskValidateArtifactResultData`、`ArtifactProbeResult`、`ArtifactProbe` 类型；`deps.probeArtifact` 可选注入；`async validateArtifact(params)`（查找 → 探针 → 四态判定 → 单一时钟 → 单次 replace fail-closed）。
+- IPC：`createArtifactProbe()`（accounts.json partition 解析、`session.fromPartition`、15s AbortController、`Referer`/`Range: bytes=0-0`、`response.body?.cancel()`；AbortError→`timeout`、其他→`error`）；`taskService` 构造注入 `probeArtifact`；handler 退化为薄适配 + 固定脱敏兜底 `'产物验证失败，请检查网络和数据目录状态'`；`saveTasks` 函数删除（全仓无引用）。
+- 行为差异（本包唯一）：持久化失败由「静默忽略、仍可能返回 success」改为 fail-closed `WRITE_ERROR`；四态判定语义与 IPC 返回形状保持。
+
+## 测试（新增 17 块 / 28 用例，≤30 块上限）
+
+| 分组 | 块数 | 覆盖 |
+| --- | --- | --- |
+| validateArtifact 基本功能 | 11 | 四态判定（it.each：valid×4 / expired×4 / invalid×6）、响应元数据落盘、timeout、网络错误、任务/产物不存在零探针零写、单一时钟、探针参数传递、单次 replace |
+| validateArtifact fail-closed | 4 | read 失败零探针/零时钟/零写、replace=false、陈旧快照、未注入探针 |
+| IPC 源码契约 | 2 | handler 不含四态业务实现、脱敏兜底 + `saveTasks` 已删除 |
+
+## 门禁结果（本会话实际执行）
+
+| 门禁 | 结果 |
+| --- | --- |
+| 专项 vitest（taskService/csv/taskRepository） | 3 files / 182 pass / 0 fail |
+| eslint（3 文件） | 0 error / 18 warning（1 既有 complexity + 17 既有 no-explicit-any，无新增） |
+| tsc main / test | 0 error |
+| git diff --check | PASS |
+| `pnpm.cmd run validate` | **PASS**（22 files / 678 pass / 0 fail；contracts 边界；renderer 3057 modules；main 构建） |
+
+## 受保护资产零修改
+
+- `packages/contracts/`、`main/preload.ts`、`src/`、`main/core/TaskRepository.ts`、`main/core/TaskEventStream.ts`、`main/utils/**`、配置文件、`pnpm-lock.yaml`、`.github/**` 未修改。
+- 未触碰 Cookie、Token、账号数据、运行数据、`.env`；未进入或修改 `D:\豆包工作室\doubao-studio-main`。
+
+## 自审裁决（单开发者自审；待总架构师复验与用户逐项授权）
+
+R0 PASS（自审）：三个 P0 全部满足；冻结包无偏离；唯一行为变化即冻结包声明的 fail-closed 修复；专项与 validate 门禁实际执行通过。
+
+## 声明
+
+- 未暂存、未提交、未推送、未创建或修改 PR
+- 未部署、未启动、未创建 Tag/Release
+- 未触碰运行目录及凭据

--- a/main/core/TaskService.ts
+++ b/main/core/TaskService.ts
@@ -5,6 +5,7 @@ import type {
   VideoDuration,
   VideoAspectRatio,
   Task,
+  TaskArtifact,
   TaskAddParams,
   TaskAssignParams,
   TaskUpdateStatusParams,
@@ -15,6 +16,7 @@ import type {
   TaskReleaseLockParams,
   TaskRunSnapshot,
   TaskRunRecord,
+  TaskValidateArtifactParams,
 } from '@doubao-studio/contracts';
 import { acquireTaskLease, renewTaskLease, canReleaseTaskLease } from '../utils/taskLease';
 import { parseCsv, normalizeCsvMode } from '../utils/csv';
@@ -30,6 +32,8 @@ export interface TaskServiceDependencies {
   id?: () => string;
   now?: () => string;
   nowMs?: () => number;
+  /** 产物网络探针（Electron session 探测由 IPC 层注入，Core 只消费结果） */
+  probeArtifact?: ArtifactProbe;
 }
 
 export type TaskServiceResult<T = undefined> =
@@ -62,6 +66,24 @@ export interface TaskCsvImportResultData {
   skipped: number;
   errors: string[];
 }
+
+/** 产物校验成功返回的数据 */
+export interface TaskValidateArtifactResultData {
+  valid: boolean;
+  artifact: TaskArtifact;
+}
+
+/** 产物网络探针结果：由 IPC 层注入的 Electron 探测产生 */
+export type ArtifactProbeResult =
+  | { kind: 'response'; statusCode: number; contentType?: string; contentLength?: number }
+  | { kind: 'timeout' }
+  | { kind: 'error'; message: string };
+
+/** 产物探针：Core 只消费结果，网络/session/账号解析由注入实现负责 */
+export type ArtifactProbe = (
+  artifact: TaskArtifact,
+  assignedAccountId: string | null,
+) => Promise<ArtifactProbeResult>;
 
 const ACTIVE = new Set<Task['status']>(['executing', 'generating', 'waiting_verification']);
 const WRITE_ERROR = '任务数据写入失败，请检查磁盘空间和数据目录权限';
@@ -565,6 +587,57 @@ export class TaskService {
         skipped: rows.length - 1 - imported.length,
         errors: errors.slice(0, 20),
       },
+    };
+  }
+
+  /** 产物校验：查找 → 注入探针 → 四态判定 → 单次 Repository 写入（fail-closed） */
+  async validateArtifact(params: TaskValidateArtifactParams): Promise<TaskServiceResult<TaskValidateArtifactResultData>> {
+    // 1. Repository read（fail-closed）
+    const tasks = this.readTasks();
+    if (!tasks) return { success: false, error: WRITE_ERROR };
+
+    // 2. 查找任务与产物；不存在时零探针/零时钟/零写入
+    const task = tasks.find((item) => item.id === params.taskId);
+    const artifact = task?.artifacts?.find((item) => item.id === params.artifactId);
+    if (!task || !artifact) return { success: false, error: '产物不存在' };
+
+    // 3. 探针依赖注入（Electron 网络探测由 IPC 层提供）
+    if (!this.deps.probeArtifact) return { success: false, error: '产物验证不可用' };
+    const probe = await this.deps.probeArtifact(artifact, task.assignedAccountId);
+
+    // 4. 单次 now() — validation.checkedAt 与 task.updatedAt 共用
+    const timestamp = this.now();
+
+    // 5. 四态判定（保持既有语义：2xx 含 206 为 valid，401/403/404/410 为 expired，其余为 invalid）
+    let validation: TaskArtifact['validation'];
+    if (probe.kind === 'response') {
+      const { statusCode } = probe;
+      const state: NonNullable<TaskArtifact['validation']>['state'] =
+        statusCode >= 200 && statusCode < 300 ? 'valid'
+          : [401, 403, 404, 410].includes(statusCode) ? 'expired'
+            : 'invalid';
+      validation = {
+        state,
+        checkedAt: timestamp,
+        contentType: probe.contentType,
+        contentLength: probe.contentLength,
+        statusCode,
+      };
+    } else if (probe.kind === 'timeout') {
+      validation = { state: 'unknown', checkedAt: timestamp, error: '验证超时' };
+    } else {
+      validation = { state: 'invalid', checkedAt: timestamp, error: probe.message };
+    }
+    artifact.validation = validation;
+    task.updatedAt = timestamp;
+
+    // 6. 单次 Repository replace（fail-closed，写失败不返回成功）
+    if (!this.persist(tasks)) return { success: false, error: WRITE_ERROR };
+
+    // 7. 返回：valid 标志由 state 派生，错误消息沿用 validation.error
+    return {
+      success: true,
+      data: { valid: validation.state === 'valid', artifact },
     };
   }
 }

--- a/main/ipc/tasks.ts
+++ b/main/ipc/tasks.ts
@@ -15,6 +15,7 @@ import { recoverInterruptedDownloads, removeExactDownloadPart } from '../utils/d
 import { TaskEventStream } from '../core/TaskEventStream';
 import { TaskRepository } from '../core/TaskRepository';
 import { TaskService } from '../core/TaskService';
+import type { ArtifactProbeResult } from '../core/TaskService';
 import type {
   Task,
   TaskErrorInfo,
@@ -36,6 +37,7 @@ import type {
   CompletedOutput,
   TaskDownloadOutputsParams,
   TaskValidateArtifactParams,
+  TaskValidateArtifactResult,
   TaskSaveAdapterReportParams,
 } from '@doubao-studio/contracts';
 
@@ -67,15 +69,42 @@ const taskRepository = new TaskRepository({
   events: taskEventStream,
   warn: (message, details) => console.warn(message, details),
 });
-const taskService = new TaskService({ store: taskRepository, defaultProjectId: getDefaultProjectId });
+const taskService = new TaskService({ store: taskRepository, defaultProjectId: getDefaultProjectId, probeArtifact: createArtifactProbe() });
 
 /** 读取所有任务（含运行时归一化） */
 function loadTasks(): Task[] {
   return taskRepository.read();
 }
 
-function saveTasks(tasks: Task[]): boolean {
-  return taskRepository.replace(tasks);
+/** 产物网络探针：Electron session/partition 探测由 IPC 边界提供，Core 只消费结果 */
+function createArtifactProbe(): (artifact: TaskArtifact, assignedAccountId: string | null) => Promise<ArtifactProbeResult> {
+  return async (artifact, assignedAccountId) => {
+    const accounts = readJSON<Array<{ id: string; partition: string }>>('accounts.json', []);
+    const account = accounts.find((item) => item.id === assignedAccountId);
+    const accountSession = account ? session.fromPartition(`persist:doubao_${account.partition}`) : session.defaultSession;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 15_000);
+    try {
+      const response = await accountSession.fetch(artifact.url, {
+        method: 'GET',
+        headers: { Referer: 'https://www.doubao.com/', Range: 'bytes=0-0' },
+        signal: controller.signal,
+      });
+      await response.body?.cancel();
+      return {
+        kind: 'response',
+        statusCode: response.status,
+        contentType: response.headers.get('content-type') || undefined,
+        contentLength: Number(response.headers.get('content-length') || 0) || undefined,
+      };
+    } catch (err: any) {
+      return err?.name === 'AbortError'
+        ? { kind: 'timeout' }
+        : { kind: 'error', message: err?.message || '未知网络错误' };
+    } finally {
+      clearTimeout(timer);
+    }
+  };
 }
 
 /** 读取下载记录（含运行时归一化 + 中断恢复） */
@@ -561,43 +590,18 @@ export function registerTaskIPC(): () => void {
 
   ipcMain.handle(
     'tasks:validateArtifact',
-    async (_event, params: TaskValidateArtifactParams): Promise<{ success: boolean; artifact?: TaskArtifact; error?: string }> => {
-      const tasks = loadTasks();
-      const task = tasks.find((item) => item.id === params.taskId);
-      const artifact = task?.artifacts?.find((item) => item.id === params.artifactId);
-      if (!task || !artifact) return { success: false, error: '产物不存在' };
-      const accounts = readJSON<Array<{ id: string; partition: string }>>('accounts.json', []);
-      const account = accounts.find((item) => item.id === task.assignedAccountId);
-      const accountSession = account ? session.fromPartition(`persist:doubao_${account.partition}`) : session.defaultSession;
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), 15_000);
+    async (_event, params: TaskValidateArtifactParams): Promise<TaskValidateArtifactResult> => {
       try {
-        const response = await accountSession.fetch(artifact.url, {
-          method: 'GET',
-          headers: { Referer: 'https://www.doubao.com/', Range: 'bytes=0-0' },
-          signal: controller.signal,
-        });
-        await response.body?.cancel();
-        const statusCode = response.status;
-        artifact.validation = {
-          state: response.ok || statusCode === 206 ? 'valid' : [401, 403, 404, 410].includes(statusCode) ? 'expired' : 'invalid',
-          checkedAt: new Date().toISOString(),
-          contentType: response.headers.get('content-type') || undefined,
-          contentLength: Number(response.headers.get('content-length') || 0) || undefined,
-          statusCode,
+        const result = await taskService.validateArtifact(params);
+        if (!result.success) return { success: false, error: result.error };
+        return {
+          success: result.data.valid,
+          artifact: result.data.artifact,
+          error: result.data.artifact.validation?.error,
         };
-      } catch (err: any) {
-        artifact.validation = {
-          state: err.name === 'AbortError' ? 'unknown' : 'invalid',
-          checkedAt: new Date().toISOString(),
-          error: err.name === 'AbortError' ? '验证超时' : err.message,
-        };
-      } finally {
-        clearTimeout(timer);
+      } catch {
+        return { success: false, error: '产物验证失败，请检查网络和数据目录状态' };
       }
-      task.updatedAt = new Date().toISOString();
-      saveTasks(tasks);
-      return { success: artifact.validation.state === 'valid', artifact, error: artifact.validation.error };
     }
   );
 

--- a/tests/unit/taskService.test.ts
+++ b/tests/unit/taskService.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import type { Task, TaskStage, TaskLock } from '@doubao-studio/contracts';
 import { TaskService } from '../../main/core/TaskService';
+import type { ArtifactProbe } from '../../main/core/TaskService';
 
 function base(id: string, status: Task['status'] = 'queued'): Task {
   return { id, prompt: id, assignedAccountId: null, status, mode: 'video', result: null, outputs: [], artifacts: [], createdAt: 'old', updatedAt: 'old' };
@@ -1217,5 +1218,199 @@ describe('TaskService importCsv fail-closed', () => {
     expect(idCount()).toBe(0);
     expect(nowCount()).toBe(0);
     expect(writeCount()).toBe(0);
+  });
+});
+
+// ==================== validateArtifact ====================
+
+const VA_NOW = '2026-08-13T23:00:00.000Z';
+const VA_WRITE_ERROR = '任务数据写入失败，请检查磁盘空间和数据目录权限';
+
+function vaTask(artifactId = 'a1'): Task {
+  const task = base('t1', 'done');
+  task.assignedAccountId = 'acc-1';
+  task.artifacts = [{
+    id: artifactId,
+    url: 'https://example.com/output.mp4',
+    kind: 'video',
+    source: 'network',
+    discoveredAt: 'old',
+  }];
+  return task;
+}
+
+function vaFixture(initial: Task[] = [vaTask()], probe: ArtifactProbe = async () => ({ kind: 'response', statusCode: 200 })) {
+  let stored = structuredClone(initial);
+  let readCount = 0;
+  let writeCount = 0;
+  let nowCount = 0;
+  const store = {
+    read: (): Task[] => { readCount++; return structuredClone(stored); },
+    replace: (tasks: Task[]): boolean => { writeCount++; stored = structuredClone(tasks); return true; },
+  };
+  const service = new TaskService({
+    store, defaultProjectId: () => 'default',
+    id: () => 'id', now: () => { nowCount++; return VA_NOW; },
+    probeArtifact: probe,
+  });
+  return { service, stored: () => stored, readCount: () => readCount, writeCount: () => writeCount, nowCount: () => nowCount };
+}
+
+describe('TaskService validateArtifact', () => {
+  it.each([200, 201, 206, 299])('HTTP %s 判定为 valid', async (statusCode) => {
+    const { service, stored } = vaFixture([vaTask()], async () => ({ kind: 'response', statusCode }));
+    const result = await service.validateArtifact({ taskId: 't1', artifactId: 'a1' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.valid).toBe(true);
+    expect(stored()[0].artifacts![0].validation?.state).toBe('valid');
+  });
+
+  it.each([401, 403, 404, 410])('HTTP %s 判定为 expired', async (statusCode) => {
+    const { service, stored } = vaFixture([vaTask()], async () => ({ kind: 'response', statusCode }));
+    const result = await service.validateArtifact({ taskId: 't1', artifactId: 'a1' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.valid).toBe(false);
+    expect(stored()[0].artifacts![0].validation?.state).toBe('expired');
+  });
+
+  it.each([400, 418, 500, 503, 301, 0])('HTTP %s 判定为 invalid', async (statusCode) => {
+    const { service, stored } = vaFixture([vaTask()], async () => ({ kind: 'response', statusCode }));
+    const result = await service.validateArtifact({ taskId: 't1', artifactId: 'a1' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.valid).toBe(false);
+    expect(stored()[0].artifacts![0].validation?.state).toBe('invalid');
+  });
+
+  it('响应元数据 contentType/contentLength/statusCode 落盘', async () => {
+    const { service, stored } = vaFixture([vaTask()], async () => ({ kind: 'response', statusCode: 200, contentType: 'video/mp4', contentLength: 12345 }));
+    await service.validateArtifact({ taskId: 't1', artifactId: 'a1' });
+    expect(stored()[0].artifacts![0].validation).toMatchObject({ state: 'valid', contentType: 'video/mp4', contentLength: 12345, statusCode: 200 });
+  });
+
+  it('timeout 判定为 unknown 并记录验证超时', async () => {
+    const { service, stored } = vaFixture([vaTask()], async () => ({ kind: 'timeout' }));
+    const result = await service.validateArtifact({ taskId: 't1', artifactId: 'a1' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.valid).toBe(false);
+    expect(stored()[0].artifacts![0].validation).toMatchObject({ state: 'unknown', error: '验证超时' });
+  });
+
+  it('网络错误判定为 invalid 并记录消息', async () => {
+    const { service, stored } = vaFixture([vaTask()], async () => ({ kind: 'error', message: 'net::ERR_FAILED' }));
+    const result = await service.validateArtifact({ taskId: 't1', artifactId: 'a1' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.valid).toBe(false);
+    expect(stored()[0].artifacts![0].validation).toMatchObject({ state: 'invalid', error: 'net::ERR_FAILED' });
+  });
+
+  it('任务不存在返回产物不存在且零探针/零写入', async () => {
+    const probe = vi.fn<ArtifactProbe>(async () => ({ kind: 'response', statusCode: 200 }));
+    const { service, writeCount } = vaFixture([vaTask()], probe);
+    expect(await service.validateArtifact({ taskId: 'nope', artifactId: 'a1' })).toEqual({ success: false, error: '产物不存在' });
+    expect(probe).not.toHaveBeenCalled();
+    expect(writeCount()).toBe(0);
+  });
+
+  it('产物不存在返回产物不存在且零探针/零写入', async () => {
+    const probe = vi.fn<ArtifactProbe>(async () => ({ kind: 'response', statusCode: 200 }));
+    const { service, writeCount } = vaFixture([vaTask()], probe);
+    expect(await service.validateArtifact({ taskId: 't1', artifactId: 'nope' })).toEqual({ success: false, error: '产物不存在' });
+    expect(probe).not.toHaveBeenCalled();
+    expect(writeCount()).toBe(0);
+  });
+
+  it('validation.checkedAt 与 task.updatedAt 共用单一时钟', async () => {
+    const { service, stored, nowCount } = vaFixture();
+    await service.validateArtifact({ taskId: 't1', artifactId: 'a1' });
+    expect(nowCount()).toBe(1);
+    expect(stored()[0].artifacts![0].validation?.checkedAt).toBe(VA_NOW);
+    expect(stored()[0].updatedAt).toBe(VA_NOW);
+  });
+
+  it('探针收到产物与账号指派参数', async () => {
+    const probe = vi.fn<ArtifactProbe>(async () => ({ kind: 'response', statusCode: 200 }));
+    const { service } = vaFixture([vaTask()], probe);
+    await service.validateArtifact({ taskId: 't1', artifactId: 'a1' });
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(probe.mock.calls[0][0]).toMatchObject({ id: 'a1', url: 'https://example.com/output.mp4' });
+    expect(probe.mock.calls[0][1]).toBe('acc-1');
+  });
+
+  it('成功路径只调用一次 Repository replace', async () => {
+    const { service, writeCount } = vaFixture();
+    await service.validateArtifact({ taskId: 't1', artifactId: 'a1' });
+    expect(writeCount()).toBe(1);
+  });
+});
+
+describe('TaskService validateArtifact fail-closed', () => {
+  it('read 失败返回 WRITE_ERROR 且零探针/零时钟/零写', async () => {
+    const probe = vi.fn<ArtifactProbe>(async () => ({ kind: 'response', statusCode: 200 }));
+    const nowFn = vi.fn(() => VA_NOW);
+    let writeCount = 0;
+    const service = new TaskService({
+      store: { read: () => { throw new Error('read failed'); }, replace: () => { writeCount++; return true; } },
+      defaultProjectId: () => 'default', id: () => 'id', now: nowFn, probeArtifact: probe,
+    });
+    expect(await service.validateArtifact({ taskId: 't1', artifactId: 'a1' })).toEqual({ success: false, error: VA_WRITE_ERROR });
+    expect(probe).not.toHaveBeenCalled();
+    expect(nowFn).not.toHaveBeenCalled();
+    expect(writeCount).toBe(0);
+  });
+
+  it('replace=false 时 fail-closed 返回 WRITE_ERROR', async () => {
+    const service = new TaskService({
+      store: { read: () => structuredClone([vaTask()]), replace: () => false },
+      defaultProjectId: () => 'default', id: () => 'id', now: () => VA_NOW,
+      probeArtifact: async () => ({ kind: 'response', statusCode: 200 }),
+    });
+    expect(await service.validateArtifact({ taskId: 't1', artifactId: 'a1' })).toEqual({ success: false, error: VA_WRITE_ERROR });
+  });
+
+  it('Repository 陈旧快照异常时 fail-closed 返回 WRITE_ERROR', async () => {
+    const service = new TaskService({
+      store: { read: () => structuredClone([vaTask()]), replace: () => { throw new Error('TASK_REPOSITORY_STALE_SNAPSHOT'); } },
+      defaultProjectId: () => 'default', id: () => 'id', now: () => VA_NOW,
+      probeArtifact: async () => ({ kind: 'response', statusCode: 200 }),
+    });
+    expect(await service.validateArtifact({ taskId: 't1', artifactId: 'a1' })).toEqual({ success: false, error: VA_WRITE_ERROR });
+  });
+
+  it('未注入探针时返回产物验证不可用且零写入', async () => {
+    const service = new TaskService({
+      store: { read: () => structuredClone([vaTask()]), replace: () => true },
+      defaultProjectId: () => 'default', id: () => 'id', now: () => VA_NOW,
+    });
+    expect(await service.validateArtifact({ taskId: 't1', artifactId: 'a1' })).toEqual({ success: false, error: '产物验证不可用' });
+  });
+});
+
+describe('IPC 接线源码契约检查：validateArtifact', () => {
+  const source = readFileSync(resolve(__dirname, '../../main/ipc/tasks.ts'), 'utf-8');
+
+  it('tasks:validateArtifact 不再包含四态业务实现，只保留薄适配', () => {
+    const firstVa = source.indexOf("'tasks:validateArtifact'");
+    const handlerStart = source.indexOf("'tasks:validateArtifact'", firstVa + 1);
+    const firstSar = source.indexOf("'tasks:saveAdapterReport'");
+    const handlerEnd = source.indexOf("'tasks:saveAdapterReport'", firstSar + 1);
+    const handlerBody = source.slice(handlerStart, handlerEnd);
+    expect(handlerBody).toMatch(/taskService\.validateArtifact\(/);
+    expect(handlerBody).not.toMatch(/\[401, 403, 404, 410\]/);
+    expect(handlerBody).not.toMatch(/statusCode === 206/);
+    expect(handlerBody).not.toMatch(/\bloadTasks\b/);
+    expect(handlerBody).not.toMatch(/\bsaveTasks\b/);
+    expect(handlerBody).not.toMatch(/\bAbortController\b/);
+  });
+
+  it('tasks:validateArtifact 使用固定脱敏兜底且 saveTasks 已删除', () => {
+    expect(source).toMatch(/'产物验证失败，请检查网络和数据目录状态'/);
+    expect(source).not.toMatch(/function\s+saveTasks\s*\(/);
+    const firstVa = source.indexOf("'tasks:validateArtifact'");
+    const handlerStart = source.indexOf("'tasks:validateArtifact'", firstVa + 1);
+    const firstSar = source.indexOf("'tasks:saveAdapterReport'");
+    const handlerEnd = source.indexOf("'tasks:saveAdapterReport'", firstSar + 1);
+    const handlerBody = source.slice(handlerStart, handlerEnd);
+    expect(handlerBody).toMatch(/catch\s*\{/);
+    expect(handlerBody).not.toMatch(/err\.message/);
   });
 });


### PR DESCRIPTION
## DOUBAO-CORE-TASK-VALIDATE-ARTIFACT-01

产物校验业务从 	asks:validateArtifact IPC handler 迁入 Core TaskService.validateArtifact；Electron 网络探针（session partition、15s abort）由 IPC 层注入，Core 负责查找、四态状态机（valid/expired/invalid/unknown）、单一时钟与 fail-closed 持久化。

### 交付
- P0-1 Core validateArtifact：查找 + 四态判定 + 单一时间源 + 探针依赖注入（Core 零 Electron/session/accounts.json 依赖）。
- P0-2 Repository fail-closed：读/写失败或陈旧快照 → WRITE_ERROR，写失败绝不返回成功；删除无调用方的 saveTasks（残余风险根除）。
- P0-3 IPC 薄适配 + 固定脱敏兜底 + 17 测试块 / 28 用例（参数化）。

### 行为变化（唯一）
持久化失败由「静默忽略、仍可能返回 success」改为 fail-closed WRITE_ERROR；四态判定语义与 IPC 返回形状不变。

### 验证
- 专项 vitest：3 files / 182 pass / 0 fail
- eslint（3 文件）：0 error / 18 warning（无新增）
- tsc main/test 0 error；git diff --check PASS
- pnpm.cmd run validate：PASS（22 files / 678 pass；contracts 边界；renderer + main 构建）

### 边界
- contracts、preload、renderer、TaskRepository、TaskEventStream、utils、配置、lockfile、.github 零修改
- 不部署、不启动、不创建 Tag/Release