### PR TITLE
refactor(core): add read-only task query service

### DIFF
--- a/docs/handoffs/2026-08-13-doubao-core-task-query-01.md
+++ b/docs/handoffs/2026-08-13-doubao-core-task-query-01.md
@@ -1,0 +1,106 @@
+# DOUBAO-CORE-TASK-QUERY-01 冻结验收包 + 实施记录
+
+- 状态：冻结后实施（用户连续授权：提交/推送/Draft PR/CI/Ready/合并；不部署、不启动）
+- 基线：`origin/main` `f869d56940f53d9e60dbf03541b6ea95a9f7d651`（PR #17 merge，含产物校验服务化）
+- 工作树：`D:\豆包工作室\doubao-core-task-query-01`
+- 分支：`glm/doubao-core-task-query-01`
+- 治理：`D:\项目架构师\DEVELOPMENT_EFFICIENCY_GOVERNANCE.md` 已读；单开发者自审 + 总架构师复验 + 用户连续授权
+
+## 核心目标
+
+补完 Core 分层读路径：把 `tasks:list`、`tasks:getCompletedOutputs`、`tasks:exportDiagnostics` 任务部分迁入 TaskService 只读查询方法；IPC 不再直接读仓库；删除 `loadTasks`。本包只读、零写入。
+
+## P0 清单
+
+### P0-1：Core 只读查询方法
+
+- `getTasks(): TaskServiceResult<Task[]>`：返回全部任务；read 失败 → `WRITE_ERROR`。
+- `getCompletedOutputs(): TaskServiceResult<CompletedOutput[]>`：过滤 `status==='done' && outputs.length>0`，投影 `taskId/prompt/outputs/accountId/mode`（与现有 handler 完全一致）；read 失败 → `WRITE_ERROR`。
+- `buildTaskDiagnostics(): TaskServiceResult<Task[]>`：脱敏任务投影（prompt→长度标记、outputs→`[产物地址 N]`、artifacts.url→`[已脱敏]`、attachments/audioAttachment→注入 basename）；read 失败 → `WRITE_ERROR`。
+- 三个方法零写入、不调用 `persist`。
+
+### P0-2：IPC 薄适配与 loadTasks 删除
+
+- `tasks:list` / `tasks:getCompletedOutputs`：只调用 Core 查询方法；失败时抛稳定错误（不再裸抛仓库错误）。
+- `tasks:exportDiagnostics`：任务部分替换为 `taskService.buildTaskDiagnostics()`，失败返回 `WRITE_ERROR`；账号/下载脱敏与写盘仍留在 IPC（既有边界）。
+- `loadTasks` 函数删除（本包后无调用方）；`loadDownloadJobs` 保留。
+- 路径脱敏依赖注入：`TaskServiceDependencies.basename?: (value: string) => string`，IPC 注入 `require('path').basename`；Core 默认回退为按 `\`/`/` 截取末段（纯字符串，不依赖 Node path）。Core 零 Electron/路径/仓库直连依赖。
+
+### P0-3：专项测试与契约不变
+
+- 新增专项测试 ≤30 块、优先参数化；IPC 接线使用源码契约检查。
+- `packages/contracts/`、preload、renderer、IPC channel 名、返回形状全部不变。
+
+## 允许修改文件（4 文件 allowlist）
+
+- `main/core/TaskService.ts`
+- `main/ipc/tasks.ts`
+- `tests/unit/taskService.test.ts`
+- `docs/handoffs/2026-08-13-doubao-core-task-query-01.md`
+
+## 禁止触碰资产
+
+- `packages/contracts/`、`main/preload.ts`、`src/`、`main/core/TaskRepository.ts`、`main/core/TaskEventStream.ts`、`main/utils/**`
+- 配置文件、`package.json`、`pnpm-lock.yaml`、`.github/**`、`scripts/`、`schemas/`
+- Cookie、Token、账号数据、运行数据、`.env`、`D:\豆包工作室\doubao-studio-main`
+
+## 行为保持与明确非目标
+
+- 三个 IPC 返回形状与过滤/脱敏语义不变；唯一行为变化：读失败时由「裸抛仓库异常」改为稳定 `WRITE_ERROR`（`tasks:list`/`getCompletedOutputs` 抛稳定错误，`exportDiagnostics` 返回稳定错误）。
+- 不做 CLI/MCP/HTTP、不新增 IPC 通道、不做写路径改动、不动 `tasks:validateArtifact` 之外的其他 handler。
+
+## 门禁
+
+- 日常：专项 vitest（taskService/csv/taskRepository）+ 修改文件 eslint + `git diff --check`。
+- 候选：`pnpm.cmd run validate`。
+
+## 完成与停止条件
+
+- 三个 P0 全部满足；适用门禁通过；受保护资产零修改；报告与 Git/测试事实一致；最多两轮整改。
+
+---
+
+# 实施记录（2026-08-13，同文件续写）
+
+## 最终 Git 状态（未提交）
+
+- tracked 修改：`main/core/TaskService.ts`（M）、`main/ipc/tasks.ts`（M）、`tests/unit/taskService.test.ts`（M）
+- untracked 新增：`docs/handoffs/2026-08-13-doubao-core-task-query-01.md`（本文件）
+- 无其他改动；未进入或修改 `D:\豆包工作室\doubao-studio-main`
+
+## 实现要点
+
+- `TaskService` 新增 `getTasks` / `getCompletedOutputs` / `buildTaskDiagnostics` 三个只读方法（零写入）；deps 新增可选 `basename`，默认按 `\`/`/` 截取末段。
+- IPC：三个 handler 退化为薄适配；`loadTasks` 删除；TaskService 构造注入 `basename: (value) => require('path').basename(value)`。
+
+## 测试（新增 17 块，≤30 块上限；本包用例无参数化扩展，用例数=块数）
+
+| 分组 | 块数 | 覆盖 |
+| --- | --- | --- |
+| getTasks | 3 | 返回全部任务与顺序、read 失败 WRITE_ERROR、零写入 |
+| getCompletedOutputs | 4 | done+产物过滤、投影字段与顺序、read 失败、零写入 |
+| buildTaskDiagnostics | 8 | prompt 长度标记、attachments/audioAttachment 注入 basename、outputs/artifacts 掩码、默认 basename 截取、字段保留、read 失败、零写入 |
+| IPC 源码契约 | 2 | list/getCompletedOutputs 薄适配 + loadTasks 删除 + basename 注入；exportDiagnostics 任务部分下沉 |
+
+## 门禁结果（本会话实际执行）
+
+| 门禁 | 结果 |
+| --- | --- |
+| 专项 vitest（taskService/csv/taskRepository） | 3 files / 199 pass / 0 fail |
+| eslint（3 文件） | 0 error / 18 warning（与基线相同，无新增） |
+| tsc main / test | 0 error |
+| git diff --check | PASS |
+| `pnpm.cmd run validate` | **PASS**（22 files / 695 pass / 0 fail；contracts 边界；renderer 3057 modules；main 构建） |
+
+## 受保护资产零修改
+
+- `packages/contracts/`、`main/preload.ts`、`src/`、`main/core/TaskRepository.ts`、`main/core/TaskEventStream.ts`、`main/utils/**`、配置文件、`pnpm-lock.yaml`、`.github/**` 未修改。
+- 未触碰 Cookie、Token、账号数据、运行数据、`.env`；未进入或修改 `D:\豆包工作室\doubao-studio-main`。
+
+## 自审裁决（单开发者自审；总架构师复验后按连续授权走 Git 链）
+
+R0 PASS（自审）：三个 P0 全部满足；`loadTasks` 删除后 tasks.ts 只余 `loadDownloadJobs`（下载域）；三个查询 IPC 返回形状与过滤/脱敏语义不变，唯一行为变化为读失败从裸抛仓库异常改为稳定 `WRITE_ERROR`；受保护资产零修改。
+
+## 声明
+
+- 未部署、未启动、未创建 Tag/Release；未触碰运行目录及凭据。

--- a/main/core/TaskService.ts
+++ b/main/core/TaskService.ts
@@ -17,6 +17,7 @@ import type {
   TaskRunSnapshot,
   TaskRunRecord,
   TaskValidateArtifactParams,
+  CompletedOutput,
 } from '@doubao-studio/contracts';
 import { acquireTaskLease, renewTaskLease, canReleaseTaskLease } from '../utils/taskLease';
 import { parseCsv, normalizeCsvMode } from '../utils/csv';
@@ -34,6 +35,8 @@ export interface TaskServiceDependencies {
   nowMs?: () => number;
   /** 产物网络探针（Electron session 探测由 IPC 层注入，Core 只消费结果） */
   probeArtifact?: ArtifactProbe;
+  /** 诊断脱敏用的路径 basename（IPC 注入 path.basename；Core 默认按分隔符截取末段） */
+  basename?: (value: string) => string;
 }
 
 export type TaskServiceResult<T = undefined> =
@@ -103,11 +106,13 @@ export class TaskService {
   private readonly id: () => string;
   private readonly now: () => string;
   private readonly nowMs: () => number;
+  private readonly basename: (value: string) => string;
 
   constructor(private readonly deps: TaskServiceDependencies) {
     this.id = deps.id || randomUUID;
     this.now = deps.now || (() => new Date().toISOString());
     this.nowMs = deps.nowMs || (() => Date.now());
+    this.basename = deps.basename || ((value) => value.split(/[\\/]/).pop() || value);
   }
 
   private readTasks(): Task[] | null {
@@ -638,6 +643,48 @@ export class TaskService {
     return {
       success: true,
       data: { valid: validation.state === 'valid', artifact },
+    };
+  }
+
+  /** 只读查询：返回全部任务（零写入） */
+  getTasks(): TaskServiceResult<Task[]> {
+    const tasks = this.readTasks();
+    if (!tasks) return { success: false, error: WRITE_ERROR };
+    return { success: true, data: tasks };
+  }
+
+  /** 只读查询：已完成且有产物的任务摘要（零写入） */
+  getCompletedOutputs(): TaskServiceResult<CompletedOutput[]> {
+    const tasks = this.readTasks();
+    if (!tasks) return { success: false, error: WRITE_ERROR };
+    return {
+      success: true,
+      data: tasks
+        .filter((task) => task.status === 'done' && task.outputs.length > 0)
+        .map((task) => ({
+          taskId: task.id,
+          prompt: task.prompt,
+          outputs: task.outputs,
+          accountId: task.assignedAccountId,
+          mode: task.mode,
+        })),
+    };
+  }
+
+  /** 只读查询：导出诊断用的脱敏任务投影（路径名经注入 basename 收敛，零写入） */
+  buildTaskDiagnostics(): TaskServiceResult<Task[]> {
+    const tasks = this.readTasks();
+    if (!tasks) return { success: false, error: WRITE_ERROR };
+    return {
+      success: true,
+      data: tasks.map((task) => ({
+        ...task,
+        prompt: `[已脱敏，长度 ${task.prompt.length}]`,
+        attachments: (task.attachments || []).map((item) => this.basename(item)),
+        audioAttachment: task.audioAttachment ? this.basename(task.audioAttachment) : undefined,
+        outputs: task.outputs.map((_, index) => `[产物地址 ${index + 1}]`),
+        artifacts: (task.artifacts || []).map((artifact) => ({ ...artifact, url: '[已脱敏]' })),
+      })),
     };
   }
 }

--- a/main/ipc/tasks.ts
+++ b/main/ipc/tasks.ts
@@ -69,12 +69,12 @@ const taskRepository = new TaskRepository({
   events: taskEventStream,
   warn: (message, details) => console.warn(message, details),
 });
-const taskService = new TaskService({ store: taskRepository, defaultProjectId: getDefaultProjectId, probeArtifact: createArtifactProbe() });
-
-/** 读取所有任务（含运行时归一化） */
-function loadTasks(): Task[] {
-  return taskRepository.read();
-}
+const taskService = new TaskService({
+  store: taskRepository,
+  defaultProjectId: getDefaultProjectId,
+  probeArtifact: createArtifactProbe(),
+  basename: (value) => require('path').basename(value),
+});
 
 /** 产物网络探针：Electron session/partition 探测由 IPC 边界提供，Core 只消费结果 */
 function createArtifactProbe(): (artifact: TaskArtifact, assignedAccountId: string | null) => Promise<ArtifactProbeResult> {
@@ -167,8 +167,9 @@ export function registerTaskIPC(): () => void {
   writeJSON('schema.json', { version: 6, appVersion: '2.0.0', updatedAt: new Date().toISOString() });
   // ---- 获取所有任务 ----
   ipcMain.handle('tasks:list', async (): Promise<Task[]> => {
-    const tasks = loadTasks();
-    return tasks;
+    const result = taskService.getTasks();
+    if (!result.success) throw new Error(result.error);
+    return result.data;
   });
 
   // ---- 添加任务（支持批量 + 指定模式 + 视频配置 + 附件） ----
@@ -311,16 +312,9 @@ export function registerTaskIPC(): () => void {
   ipcMain.handle(
     'tasks:getCompletedOutputs',
     async (): Promise<CompletedOutput[]> => {
-      const tasks = loadTasks();
-      return tasks
-        .filter((t) => t.status === 'done' && t.outputs.length > 0)
-        .map((t) => ({
-          taskId: t.id,
-          prompt: t.prompt,
-          outputs: t.outputs,
-          accountId: t.assignedAccountId,
-          mode: t.mode,
-        }));
+      const result = taskService.getCompletedOutputs();
+      if (!result.success) throw new Error(result.error);
+      return result.data;
     }
   );
 
@@ -548,14 +542,9 @@ export function registerTaskIPC(): () => void {
         });
         if (result.canceled || !result.filePath) return { success: false };
 
-        const tasks = loadTasks().map((task) => ({
-          ...task,
-          prompt: `[已脱敏，长度 ${task.prompt.length}]`,
-          attachments: (task.attachments || []).map((item) => path.basename(item)),
-          audioAttachment: task.audioAttachment ? path.basename(task.audioAttachment) : undefined,
-          outputs: task.outputs.map((_, index) => `[产物地址 ${index + 1}]`),
-          artifacts: (task.artifacts || []).map((artifact) => ({ ...artifact, url: '[已脱敏]' })),
-        }));
+        const tasksResult = taskService.buildTaskDiagnostics();
+        if (!tasksResult.success) return { success: false, error: tasksResult.error };
+        const tasks = tasksResult.data;
         const accounts = readJSON<Array<Record<string, any>>>('accounts.json', []).map((account) => ({
           id: account.id,
           name: account.name,

--- a/tests/unit/taskService.test.ts
+++ b/tests/unit/taskService.test.ts
@@ -1414,3 +1414,202 @@ describe('IPC 接线源码契约检查：validateArtifact', () => {
     expect(handlerBody).not.toMatch(/err\.message/);
   });
 });
+
+// ==================== 只读任务查询 ====================
+
+const Q_WRITE_ERROR = '任务数据写入失败，请检查磁盘空间和数据目录权限';
+
+function qTask(id: string, status: Task['status'], outputs: string[] = []): Task {
+  const task = base(id, status);
+  task.outputs = outputs;
+  return task;
+}
+
+function queryFixture(initial: Task[] = [], basename?: (value: string) => string) {
+  let stored = structuredClone(initial);
+  let writeCount = 0;
+  const store = {
+    read: (): Task[] => structuredClone(stored),
+    replace: (tasks: Task[]): boolean => { writeCount++; stored = structuredClone(tasks); return true; },
+  };
+  const service = new TaskService({
+    store, defaultProjectId: () => 'default', id: () => 'id', now: () => 'now',
+    basename,
+  });
+  return { service, stored: () => stored, writeCount: () => writeCount };
+}
+
+describe('TaskService 只读查询 getTasks', () => {
+  it('返回全部任务且保持顺序', () => {
+    const { service } = queryFixture([qTask('t1', 'queued'), qTask('t2', 'done')]);
+    const result = service.getTasks();
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.map((task) => task.id)).toEqual(['t1', 't2']);
+  });
+
+  it('read 失败返回 WRITE_ERROR', () => {
+    const service = new TaskService({
+      store: { read: () => { throw new Error('read failed'); }, replace: () => true },
+      defaultProjectId: () => 'default', id: () => 'id', now: () => 'now',
+    });
+    expect(service.getTasks()).toEqual({ success: false, error: Q_WRITE_ERROR });
+  });
+
+  it('零写入', () => {
+    const { service, writeCount } = queryFixture([qTask('t1', 'queued')]);
+    service.getTasks();
+    expect(writeCount()).toBe(0);
+  });
+});
+
+describe('TaskService 只读查询 getCompletedOutputs', () => {
+  it('只返回 done 且有产物的任务', () => {
+    const { service } = queryFixture([
+      qTask('t1', 'done', ['u1']),
+      qTask('t2', 'done'),
+      qTask('t3', 'queued', ['u2']),
+      qTask('t4', 'fail', ['u3']),
+    ]);
+    const result = service.getCompletedOutputs();
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.map((item) => item.taskId)).toEqual(['t1']);
+  });
+
+  it('投影字段完整且保持顺序', () => {
+    const first = qTask('t1', 'done', ['u1', 'u2']);
+    first.assignedAccountId = 'acc-9';
+    first.mode = 'video';
+    first.prompt = '你好';
+    const second = qTask('t2', 'done', ['u3']);
+    const { service } = queryFixture([first, second]);
+    const result = service.getCompletedOutputs();
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data[0]).toEqual({ taskId: 't1', prompt: '你好', outputs: ['u1', 'u2'], accountId: 'acc-9', mode: 'video' });
+      expect(result.data.map((item) => item.taskId)).toEqual(['t1', 't2']);
+    }
+  });
+
+  it('read 失败返回 WRITE_ERROR', () => {
+    const service = new TaskService({
+      store: { read: () => { throw new Error('read failed'); }, replace: () => true },
+      defaultProjectId: () => 'default', id: () => 'id', now: () => 'now',
+    });
+    expect(service.getCompletedOutputs()).toEqual({ success: false, error: Q_WRITE_ERROR });
+  });
+
+  it('零写入', () => {
+    const { service, writeCount } = queryFixture([qTask('t1', 'done', ['u1'])]);
+    service.getCompletedOutputs();
+    expect(writeCount()).toBe(0);
+  });
+});
+
+describe('TaskService 只读查询 buildTaskDiagnostics', () => {
+  function diagTask(): Task {
+    const task = qTask('t1', 'done', ['u1', 'u2']);
+    task.prompt = 'secret prompt';
+    task.assignedAccountId = 'acc-9';
+    task.attachments = ['C:\\dir\\a.png', 'D:\\x\\b.jpg'];
+    task.audioAttachment = 'C:\\dir\\au.mp3';
+    task.artifacts = [{ id: 'art-1', url: 'https://x/v.mp4', kind: 'video', source: 'network', discoveredAt: 'old' }];
+    return task;
+  }
+
+  it('prompt 脱敏为长度标记且其他字段原样保留', () => {
+    const { service } = queryFixture([diagTask()], (value) => `BASE:${value}`);
+    const result = service.buildTaskDiagnostics();
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data[0].prompt).toBe('[已脱敏，长度 13]');
+      expect(result.data[0]).toMatchObject({ id: 't1', status: 'done', assignedAccountId: 'acc-9' });
+    }
+  });
+
+  it('attachments 使用注入 basename', () => {
+    const { service } = queryFixture([diagTask()], (value) => `BASE:${value}`);
+    const result = service.buildTaskDiagnostics();
+    if (result.success) {
+      expect(result.data[0].attachments).toEqual(['BASE:C:\\dir\\a.png', 'BASE:D:\\x\\b.jpg']);
+    }
+  });
+
+  it('audioAttachment 使用注入 basename，空值规范为 undefined', () => {
+    const withAudio = diagTask();
+    const withoutAudio = diagTask();
+    withoutAudio.audioAttachment = undefined;
+    const { service } = queryFixture([withAudio, withoutAudio], (value) => `BASE:${value}`);
+    const result = service.buildTaskDiagnostics();
+    if (result.success) {
+      expect(result.data[0].audioAttachment).toBe('BASE:C:\\dir\\au.mp3');
+      expect(result.data[1].audioAttachment).toBeUndefined();
+    }
+  });
+
+  it('outputs 掩码为序号标记', () => {
+    const { service } = queryFixture([diagTask()], (value) => `BASE:${value}`);
+    const result = service.buildTaskDiagnostics();
+    if (result.success) expect(result.data[0].outputs).toEqual(['[产物地址 1]', '[产物地址 2]']);
+  });
+
+  it('artifacts 的 url 掩码，其余字段保留', () => {
+    const { service } = queryFixture([diagTask()], (value) => `BASE:${value}`);
+    const result = service.buildTaskDiagnostics();
+    if (result.success) {
+      expect(result.data[0].artifacts![0]).toMatchObject({ id: 'art-1', url: '[已脱敏]', kind: 'video' });
+    }
+  });
+
+  it('默认 basename 按分隔符截取末段', () => {
+    const { service } = queryFixture([diagTask()]);
+    const result = service.buildTaskDiagnostics();
+    if (result.success) {
+      expect(result.data[0].attachments).toEqual(['a.png', 'b.jpg']);
+      expect(result.data[0].audioAttachment).toBe('au.mp3');
+    }
+  });
+
+  it('read 失败返回 WRITE_ERROR', () => {
+    const service = new TaskService({
+      store: { read: () => { throw new Error('read failed'); }, replace: () => true },
+      defaultProjectId: () => 'default', id: () => 'id', now: () => 'now',
+    });
+    expect(service.buildTaskDiagnostics()).toEqual({ success: false, error: Q_WRITE_ERROR });
+  });
+
+  it('零写入', () => {
+    const { service, writeCount } = queryFixture([diagTask()], (value) => `BASE:${value}`);
+    service.buildTaskDiagnostics();
+    expect(writeCount()).toBe(0);
+  });
+});
+
+describe('IPC 接线源码契约检查：只读查询', () => {
+  const source = readFileSync(resolve(__dirname, '../../main/ipc/tasks.ts'), 'utf-8');
+
+  it('tasks:list / tasks:getCompletedOutputs 退化为薄适配且 loadTasks 已删除', () => {
+    expect(source).not.toMatch(/function\s+loadTasks\s*\(/);
+    expect(source).toMatch(/basename: \(value\) => require\('path'\)\.basename\(value\)/);
+    const listStart = source.indexOf("'tasks:list'", source.indexOf("'tasks:list'") + 1);
+    const listEnd = source.indexOf("'tasks:add'", source.indexOf("'tasks:add'") + 1);
+    const listBody = source.slice(listStart, listEnd);
+    expect(listBody).toMatch(/taskService\.getTasks\(\)/);
+    expect(listBody).not.toMatch(/\bloadTasks\b/);
+    const coStart = source.indexOf("'tasks:getCompletedOutputs'", source.indexOf("'tasks:getCompletedOutputs'") + 1);
+    const coEnd = source.indexOf("'tasks:selectImages'", source.indexOf("'tasks:selectImages'") + 1);
+    const coBody = source.slice(coStart, coEnd);
+    expect(coBody).toMatch(/taskService\.getCompletedOutputs\(\)/);
+    expect(coBody).not.toMatch(/\bloadTasks\b/);
+    expect(coBody).not.toMatch(/\.filter\(/);
+  });
+
+  it('exportDiagnostics 任务部分调用 buildTaskDiagnostics，脱敏逻辑不在 handler', () => {
+    const exStart = source.indexOf("'tasks:exportDiagnostics'", source.indexOf("'tasks:exportDiagnostics'") + 1);
+    const exEnd = source.indexOf("'tasks:validateArtifact'", source.indexOf("'tasks:validateArtifact'") + 1);
+    const exBody = source.slice(exStart, exEnd);
+    expect(exBody).toMatch(/taskService\.buildTaskDiagnostics\(\)/);
+    expect(exBody).not.toMatch(/\bloadTasks\b/);
+    expect(exBody).not.toMatch(/已脱敏，长度/);
+    expect(exBody).not.toMatch(/\[产物地址/);
+  });
+});


### PR DESCRIPTION
## DOUBAO-CORE-TASK-QUERY-01

读路径收口：	asks:list、	asks:getCompletedOutputs 与 	asks:exportDiagnostics 任务部分迁入 Core 只读查询方法；IPC 不再直接读仓库，loadTasks 删除。

### 交付
- P0-1 Core 只读查询：getTasks / getCompletedOutputs / uildTaskDiagnostics（诊断脱敏投影，路径 basename 依赖注入）；零写入；read 失败 → WRITE_ERROR。
- P0-2 IPC 薄适配：三个 handler 只调用 Core；loadTasks 删除；账号/下载脱敏与写盘仍留在 IPC 既有边界。
- P0-3 专项测试 17 块（≤30）；contracts、channel、返回形状全部不变。

### 行为变化（唯一）
读失败由「裸抛仓库异常」改为稳定 WRITE_ERROR（list/getCompletedOutputs 抛稳定错误，exportDiagnostics 返回稳定错误）。

### 验证
- 专项 vitest：3 files / 199 pass / 0 fail
- eslint（3 文件）：0 error / 18 warning（无新增）
- tsc / git diff --check：PASS
- pnpm.cmd run validate：PASS（22 files / 695 pass；contracts 边界；renderer + main 构建）

### 边界
- contracts、preload、renderer、TaskRepository、TaskEventStream、utils、配置、lockfile、.github 零修改
- 不部署、不启动、不创建 Tag/Release