### PR TITLE
feat(cli-mcp): add read-only CLI/MCP boundary over Core TaskService

### DIFF
--- a/docs/handoffs/2026-08-16-doubao-cli-mcp-boundary-01.md
+++ b/docs/handoffs/2026-08-16-doubao-cli-mcp-boundary-01.md
@@ -1,0 +1,43 @@
+# DOUBAO-CLI-MCP-BOUNDARY-01 冻结验收包 + 实施记录
+
+- 状态：D-SPRINT-02 项 A-3（用户连续授权）；分支 `doubao-cli-mcp-boundary-01`（基于 origin/main `0c4a9d7`）。
+- 目标：豆包外部接口边界准备——CLI/MCP 只读接口与 Core TaskService 的纯逻辑边界（零 Electron 依赖），为后续 CLI/MCP stdio 接线包冻结边界。
+
+## P0 清单
+
+- P0-1：`main/cli/doubaoCli.ts`——只读 CLI 动作集合（listTasks/taskDetail/completedOutputs/diagnostics），稳定 JSON 形状，prompt 截断 120 字符、诊断全脱敏，零写入。
+- P0-2：`main/mcp/doubaoMcpTools.ts`——MCP 工具注册表（doubao.list_tasks / doubao.get_task）+ 处理器映射，缺参 fail-closed（MISSING_TASK_ID），零网络/零 Electron。
+- P0-3：`tests/unit/cli-mcp-boundary.test.ts`——源码级「无 electron 依赖」断言 + 过滤/截断/投影/脱敏/MCP 处理器 5 组契约测试。
+- P0-4：门禁：本包专项 + `pnpm run ts-check`（main tsconfig 覆盖新文件）+ 既有 validate（不跑 Electron 打包）；PR CI。
+
+## 允许修改文件（5 个）
+
+- `main/cli/doubaoCli.ts`（新增）、`main/mcp/doubaoMcpTools.ts`（新增）
+- `tests/unit/cli-mcp-boundary.test.ts`（新增）
+- `docs/handoffs/2026-08-16-doubao-cli-mcp-boundary-01.md`（本文件）
+- （如 tsconfig 需要包含新目录才 type-check，则机械更新相应 include——实施时决定，禁止扩面）
+
+## 禁止事项
+
+- 不实现 stdio 接线/分发进程（后续独立包）；不改 Core 业务逻辑；不 import electron；不部署；不启动；不触碰 `D:\豆包工作室\doubao-studio-main`（受保护现场）。
+
+---
+
+# 实施记录（2026-08-16，同文件续写）
+
+## 门禁结果
+
+| 门禁 | 结果 |
+| --- | --- |
+| 专项 `tests/unit/cli-mcp-boundary.test.ts` | 见运行记录 |
+| `pnpm run ts-check` | 见运行记录 |
+| `pnpm run lint`（新增文件） | 见运行记录 |
+| PR CI | 见 PR 结果 |
+
+## 自审裁决
+
+（完成后补）
+
+## 声明
+
+未部署、未启动；未触碰受保护现场 doubao-studio-main；Core 零修改。

--- a/main/cli/doubaoCli.ts
+++ b/main/cli/doubaoCli.ts
@@ -1,0 +1,93 @@
+/**
+ * DOUBAO-CLI-MCP-BOUNDARY-01：CLI 外部接口边界（纯逻辑，零 Electron 依赖）。
+ *
+ * 设计约束：
+ * - 只读：仅消费 TaskService.getTasks / getCompletedOutputs / buildTaskDiagnostics，零写入。
+ * - 依赖注入：TaskService 由调用方构造（CLI 入口注入文件存储、MCP 入口同构），本文件不 import electron。
+ * - 返回形状稳定：{ ok: boolean; error?: string; data?: unknown }（JSON 可序列化）。
+ */
+import { TaskService } from '../core/TaskService';
+import type { Task } from '@doubao-studio/contracts';
+
+export interface CliListOptions {
+  status?: string;
+  keyword?: string;
+  limit?: number;
+}
+
+export interface CliTaskDetail {
+  id: string;
+  status: string;
+  mode: string;
+  prompt: string;
+  outputCount: number;
+  assignedAccountId?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/** 只读 CLI 动作集合：所有方法返回稳定 JSON 形状，不抛业务异常。 */
+export function buildCliActions(service: TaskService) {
+  function normalize(result: { success: boolean; error?: string; data?: unknown }) {
+    if (!result.success) return { ok: false, error: result.error ?? 'UNKNOWN' };
+    return { ok: true, data: result.data };
+  }
+
+  return {
+    /** 列出任务（可选 status/keyword 过滤 + limit 截断）。 */
+    listTasks(options: CliListOptions = {}) {
+      const result = service.getTasks();
+      const base = normalize(result);
+      if (!base.ok) return base;
+      let tasks = (base.data as Task[]) || [];
+      if (options.status) tasks = tasks.filter((t) => t.status === options.status);
+      if (options.keyword) {
+        const k = options.keyword.toLowerCase();
+        tasks = tasks.filter((t) => t.prompt.toLowerCase().includes(k));
+      }
+      if (options.limit && options.limit > 0) tasks = tasks.slice(0, options.limit);
+      return {
+        ok: true,
+        data: tasks.map((t) => ({
+          id: t.id,
+          status: t.status,
+          mode: t.mode,
+          prompt: t.prompt.slice(0, 120),
+          outputCount: t.outputs.length,
+        })),
+      };
+    },
+
+    /** 单任务详情（稳定投影，不含产物原始地址）。 */
+    taskDetail(taskId: string) {
+      const result = service.getTasks();
+      const base = normalize(result);
+      if (!base.ok) return base;
+      const task = (base.data as Task[]).find((t) => t.id === taskId);
+      if (!task) return { ok: false, error: 'TASK_NOT_FOUND' };
+      const detail: CliTaskDetail = {
+        id: task.id,
+        status: task.status,
+        mode: task.mode,
+        prompt: task.prompt,
+        outputCount: task.outputs.length,
+      };
+      if (task.assignedAccountId) detail.assignedAccountId = task.assignedAccountId;
+      if (task.createdAt) detail.createdAt = task.createdAt;
+      if (task.updatedAt) detail.updatedAt = task.updatedAt;
+      return { ok: true, data: detail };
+    },
+
+    /** 已完成产物摘要。 */
+    completedOutputs() {
+      return normalize(service.getCompletedOutputs());
+    },
+
+    /** 脱敏诊断投影。 */
+    diagnostics() {
+      return normalize(service.buildTaskDiagnostics());
+    },
+  };
+}
+
+export type CliActions = ReturnType<typeof buildCliActions>;

--- a/main/mcp/doubaoMcpTools.ts
+++ b/main/mcp/doubaoMcpTools.ts
@@ -1,0 +1,58 @@
+/**
+ * DOUBAO-CLI-MCP-BOUNDARY-01：MCP 工具处理器（纯逻辑，零 Electron / 零网络）。
+ *
+ * 由 MCP stdio 入口（后续独立接线包）构造 TaskService 后调用；
+ * 本文件只负责「工具名 → 只读动作」映射与结果 JSON 序列化。
+ */
+import { TaskService } from '../core/TaskService';
+import { buildCliActions } from '../cli/doubaoCli';
+
+export interface McpToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+}
+
+/** 工具描述（MCP tools/list 注册表）。 */
+export const DOUBAO_MCP_TOOLS = [
+  {
+    name: 'doubao.list_tasks',
+    description: '只读列出豆包任务（可选 status/keyword 过滤；零写入）',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        status: { type: 'string' },
+        keyword: { type: 'string' },
+        limit: { type: 'integer' },
+      },
+    },
+  },
+  {
+    name: 'doubao.get_task',
+    description: '只读获取单个豆包任务详情（零写入）',
+    inputSchema: {
+      type: 'object',
+      properties: { taskId: { type: 'string' } },
+      required: ['taskId'],
+    },
+  },
+] as const;
+
+/** 构建 MCP 工具处理器映射（纯逻辑；结果恒为 JSON 文本）。 */
+export function buildMcpToolHandlers(service: TaskService) {
+  const cli = buildCliActions(service);
+  return {
+    'doubao.list_tasks': (args: { status?: string; keyword?: string; limit?: number } = {}): McpToolResult => {
+      const result = cli.listTasks(args);
+      return { content: [{ type: 'text', text: JSON.stringify(result) }], isError: !result.ok };
+    },
+    'doubao.get_task': (args: { taskId?: string } = {}): McpToolResult => {
+      if (!args.taskId) {
+        return { content: [{ type: 'text', text: JSON.stringify({ ok: false, error: 'MISSING_TASK_ID' }) }], isError: true };
+      }
+      const result = cli.taskDetail(args.taskId);
+      return { content: [{ type: 'text', text: JSON.stringify(result) }], isError: !result.ok };
+    },
+  };
+}
+
+export type McpToolHandlers = ReturnType<typeof buildMcpToolHandlers>;

--- a/tests/unit/cli-mcp-boundary.test.ts
+++ b/tests/unit/cli-mcp-boundary.test.ts
@@ -1,0 +1,106 @@
+/**
+ * DOUBAO-CLI-MCP-BOUNDARY-01 契约测试。
+ *
+ * 覆盖：
+ *  - CLI/MCP 边界纯逻辑：无 electron 依赖（源码断言）。
+ *  - listTasks 过滤/截断、taskDetail 稳定投影、completedOutputs、diagnostics 脱敏。
+ *  - MCP 工具注册表与处理器（含缺参 fail-closed）。
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { TaskService } from '../../main/core/TaskService';
+import { buildCliActions } from '../../main/cli/doubaoCli';
+import { buildMcpToolHandlers, DOUBAO_MCP_TOOLS } from '../../main/mcp/doubaoMcpTools';
+import type { Task } from '@doubao-studio/contracts';
+
+function makeService(tasks: Task[]): TaskService {
+  const store = { read: () => structuredClone(tasks), replace: () => false };
+  return new TaskService({ store, defaultProjectId: () => 'p1' });
+}
+
+function task(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 't1',
+    prompt: '画一只猫',
+    assignedAccountId: null,
+    status: 'queued',
+    mode: 'txt2img',
+    result: null,
+    outputs: [],
+    artifacts: [],
+    createdAt: '2026-08-16T00:00:00Z',
+    updatedAt: '2026-08-16T00:00:00Z',
+    ...overrides,
+  } as unknown as Task;
+}
+
+describe('DOUBAO-CLI-MCP-BOUNDARY-01', () => {
+  it('边界源码零 Electron 依赖（fail-closed 边界）', () => {
+    for (const file of ['main/cli/doubaoCli.ts', 'main/mcp/doubaoMcpTools.ts']) {
+      const source = readFileSync(resolve(__dirname, '..', '..', file), 'utf8');
+      expect(source.includes("from 'electron'")).toBe(false);
+      expect(source.includes("require('electron')")).toBe(false);
+    }
+  });
+
+  it('listTasks：过滤 + 截断 + 稳定投影（prompt 截 120 字符）', () => {
+    const cli = buildCliActions(makeService([
+      task({ id: 'a', status: 'done', prompt: 'x'.repeat(200) }),
+      task({ id: 'b', status: 'queued', prompt: '订单' }),
+    ]));
+    const all = cli.listTasks();
+    expect(all.ok).toBe(true);
+    expect((all.data as { id: string }[]).map((t) => t.id).sort()).toEqual(['a', 'b']);
+    const done = cli.listTasks({ status: 'done' });
+    expect((done.data as { id: string }[]).map((t) => t.id)).toEqual(['a']);
+    expect((done.data as { prompt: string }[])[0].prompt.length).toBe(120);
+    const limited = cli.listTasks({ limit: 1 });
+    expect((limited.data as unknown[]).length).toBe(1);
+    const keyword = cli.listTasks({ keyword: '订单' });
+    expect((keyword.data as { id: string }[]).map((t) => t.id)).toEqual(['b']);
+  });
+
+  it('taskDetail：存在/不存在（TASK_NOT_FOUND）', () => {
+    const cli = buildCliActions(makeService([task({ id: 'a', assignedAccountId: 'acc1' })]));
+    expect(cli.taskDetail('a')).toEqual({
+      ok: true,
+      data: {
+        id: 'a', status: 'queued', mode: 'txt2img', prompt: '画一只猫', outputCount: 0,
+        assignedAccountId: 'acc1', createdAt: '2026-08-16T00:00:00Z', updatedAt: '2026-08-16T00:00:00Z',
+      },
+    });
+    expect(cli.taskDetail('nope')).toEqual({ ok: false, error: 'TASK_NOT_FOUND' });
+  });
+
+  it('completedOutputs 仅 done 且有产物；diagnostics 全脱敏', () => {
+    const doneTask = task({
+      id: 'd',
+      status: 'done',
+      outputs: ['file://out/1.png'],
+      artifacts: [{ url: 'file://secret/1.png' } as never],
+      attachments: ['D:/secret/attach.png'],
+    });
+    const cli = buildCliActions(makeService([doneTask, task({ id: 'p' })]));
+    const outputs = cli.completedOutputs();
+    expect((outputs.data as { taskId: string }[]).map((o) => o.taskId)).toEqual(['d']);
+    const diag = cli.diagnostics();
+    const diagTask = (diag.data as Task[]).find((t) => t.id === 'd');
+    expect(diagTask?.prompt).toContain('已脱敏');
+    expect((diagTask?.artifacts || [])[0]?.url).toBe('[已脱敏]');
+    expect((diagTask?.attachments || [])[0]).not.toContain('secret');
+  });
+
+  it('MCP：工具注册表 + 处理器（含缺参 fail-closed）', () => {
+    const handlers = buildMcpToolHandlers(makeService([task({ id: 'a' })]));
+    expect(DOUBAO_MCP_TOOLS.map((t) => t.name)).toEqual(['doubao.list_tasks', 'doubao.get_task']);
+    const list = handlers['doubao.list_tasks']({ status: 'queued' });
+    expect(list.isError).toBe(false);
+    expect(JSON.parse(list.content[0].text).ok).toBe(true);
+    const missing = handlers['doubao.get_task']({});
+    expect(missing.isError).toBe(true);
+    expect(JSON.parse(missing.content[0].text).error).toBe('MISSING_TASK_ID');
+    const found = handlers['doubao.get_task']({ taskId: 'a' });
+    expect(JSON.parse(found.content[0].text).data.id).toBe('a');
+  });
+});


### PR DESCRIPTION
D-SPRINT-02 A-3：CLI/MCP 外部接口边界准备——main/cli/doubaoCli.ts（只读 list/taskDetail/completedOutputs/diagnostics，零写入零 Electron）+ main/mcp/doubaoMcpTools.ts（MCP 工具注册表与处理器，缺参 fail-closed）+ 5 组契约测试（含源码级无 electron 断言）。ts-check 全绿。stdio 接线/分发进程为后续独立包。