### PR TITLE
feat(cli-mcp): wire read-only boundary into executable CLI and MCP stdio server

### DIFF
--- a/docs/handoffs/2026-08-16-doubao-cli-wiring-01.md
+++ b/docs/handoffs/2026-08-16-doubao-cli-wiring-01.md
@@ -1,0 +1,45 @@
+# DOUBAO-CLI-WIRING-01 冻结验收包 + 实施记录
+
+- 状态：D-SPRINT-03 项 B-1（用户连续授权）；分支 `doubao-cli-mcp-boundary-01`（在 A-3 已合并代码之上继续，基于 origin/main `865c175`）。
+- 目标：CLI/MCP **stdio 接线包**——把 A-3 只读边界接成可执行入口（真实 CLI + MCP stdio 服务器），零 Electron/零写入。
+
+## P0 清单
+
+- P0-1：`main/cli/doubaoCliEntry.ts`——CLI 可执行入口（list/task/outputs/diagnostics + help；`--tasks-file` 注入 JSON 任务文件；文件存储 replace 恒 false → 零写入；`runCli` 纯函数可测）。
+- P0-2：`main/mcp/doubaoMcpServer.ts`——MCP stdio 服务器（JSON-RPC 2.0：initialize/tools/list/tools/call/ping；未知工具 isError UNKNOWN_TOOL；非 JSON 行忽略；`startMcpServer(io, tasksFile)` io 注入可测）。
+- P0-3：`package.json` 新增脚本 `cli:list` / `mcp:server`（运行编译产物 dist/main/...）。
+- P0-4：`tests/unit/cli-mcp-entry.test.ts`——CLI 三命令 + 零写入断言 + MCP 全协议 + 未知工具，共 5 测试。
+- P0-5：门禁：专项 10/10（含 A-3 5 项）、ts-check 0、eslint 0、编译产物冒烟（CLI list 实跑）、PR CI validate。
+
+## 允许修改文件（6 个）
+
+- `main/cli/doubaoCliEntry.ts`、`main/mcp/doubaoMcpServer.ts`（新增）
+- `tests/unit/cli-mcp-entry.test.ts`（新增）
+- `package.json`（仅新增两个 scripts 行）
+- `docs/handoffs/2026-08-16-doubao-cli-wiring-01.md`（本文件）
+
+## 禁止事项
+
+- 不改 Core 业务逻辑；不实现 MCP 客户端/分发进程（stdin 直连即可）；不部署；不启动；不触碰受保护现场。
+
+---
+
+# 实施记录（2026-08-16，同文件续写）
+
+## 门禁结果
+
+| 门禁 | 结果 |
+| --- | --- |
+| 专项（entry+boundary） | **10/10** |
+| `pnpm run ts-check` | 0 |
+| `npx eslint`（新增 3 文件） | 0 |
+| `pnpm run build:main` + CLI 冒烟 | 编译成功；`node dist/main/cli/doubaoCliEntry.js list` 返回 `{"ok":true,...}` exit 0 |
+| PR CI validate | 见 PR 结果 |
+
+## 自审裁决
+
+R0 PASS（自审）：入口纯逻辑零 Electron（tsconfig.main 覆盖、源码无 electron 引用）；CLI/MCP 只读且零写入（replace 恒 false 并有测试断言文件不变）；MCP 协议最小实现符合 2024-11-05 initialize 应答；未触碰 Core。
+
+## 声明
+
+未部署、未启动；受保护现场 doubao-studio-main 未触碰；Core 零修改。

--- a/main/cli/doubaoCliEntry.ts
+++ b/main/cli/doubaoCliEntry.ts
@@ -1,0 +1,91 @@
+/**
+ * DOUBAO-CLI-WIRING-01：CLI 可执行入口（接线 A-3 只读边界；零 Electron）。
+ *
+ * 运行：node dist/main/cli/doubaoCliEntry.js <command> [options]
+ *   commands: list | task <id> | outputs | diagnostics
+ *   options : --tasks-file <json>（默认 data/tasks.json）--status --keyword --limit
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { TaskService } from '../core/TaskService';
+import { buildCliActions } from './doubaoCli';
+import type { Task } from '@doubao-studio/contracts';
+
+/** JSON 文件任务存储（只读面；replace 恒 false —— CLI 无写路径）。 */
+export function createFileTaskStore(filePath: string) {
+  return {
+    read(): Task[] {
+      if (!existsSync(filePath)) return [];
+      try {
+        const parsed = JSON.parse(readFileSync(filePath, 'utf8'));
+        return Array.isArray(parsed) ? (parsed as Task[]) : [];
+      } catch {
+        return [];
+      }
+    },
+    replace(): boolean {
+      return false;
+    },
+  };
+}
+
+export interface CliRunResult {
+  exitCode: number;
+  output: string;
+}
+
+/** 纯逻辑执行体（stdout 注入便于测试）。 */
+export function runCli(args: string[], write: (s: string) => void = console.log): CliRunResult {
+  let tasksFile = 'data/tasks.json';
+  const positional: string[] = [];
+  const options: Record<string, string> = {};
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--tasks-file' && args[i + 1]) {
+      tasksFile = args[++i];
+    } else if (a.startsWith('--')) {
+      const [k, v] = a.slice(2).split('=');
+      options[k] = v ?? args[++i] ?? 'true';
+    } else {
+      positional.push(a);
+    }
+  }
+
+  const service = new TaskService({ store: createFileTaskStore(tasksFile), defaultProjectId: () => 'default' });
+  const cli = buildCliActions(service);
+  const command = positional[0] ?? 'list';
+
+  let result: { ok: boolean; error?: string; data?: unknown } = { ok: false, error: 'UNKNOWN_COMMAND' };
+  switch (command) {
+    case 'list':
+      result = cli.listTasks({
+        status: options.status,
+        keyword: options.keyword,
+        limit: options.limit ? Number(options.limit) : undefined,
+      });
+      break;
+    case 'task':
+      result = cli.taskDetail(positional[1] ?? '');
+      break;
+    case 'outputs':
+      result = cli.completedOutputs();
+      break;
+    case 'diagnostics':
+      result = cli.diagnostics();
+      break;
+    case 'help':
+      write('doubao-cli <list|task <id>|outputs|diagnostics> [--tasks-file <json>] [--status <s>] [--keyword <k>] [--limit <n>]');
+      return { exitCode: 0, output: 'help' };
+    default:
+      result = { ok: false, error: 'UNKNOWN_COMMAND' };
+  }
+
+  write(JSON.stringify(result));
+  return { exitCode: result.ok ? 0 : 1, output: JSON.stringify(result) };
+}
+
+// 仅直接执行时运行 CLI 主体
+const isDirect = typeof require !== 'undefined' && require.main === module;
+if (isDirect) {
+  const code = runCli(process.argv.slice(2)).exitCode;
+  process.exit(code);
+}

--- a/main/mcp/doubaoMcpServer.ts
+++ b/main/mcp/doubaoMcpServer.ts
@@ -1,0 +1,76 @@
+/**
+ * DOUBAO-CLI-WIRING-01：MCP stdio 服务器入口（接线 A-3 工具处理器；零 Electron / 零网络）。
+ *
+ * 协议：JSON-RPC 2.0 over stdio（initialize / tools/list / tools/call / ping）。
+ * 运行：node dist/main/mcp/doubaoMcpServer.js --tasks-file <json>
+ */
+import { createInterface } from 'node:readline';
+import { TaskService } from '../core/TaskService';
+import { buildMcpToolHandlers, DOUBAO_MCP_TOOLS } from './doubaoMcpTools';
+import { createFileTaskStore } from '../cli/doubaoCliEntry';
+
+export interface McpIo {
+  writeLine: (line: string) => void;
+  onLine: (cb: (line: string) => void) => void;
+  close: () => void;
+}
+
+export function createStdioIo(): McpIo {
+  const rl = createInterface({ input: process.stdin, output: process.stdout, terminal: false });
+  return {
+    writeLine: (line: string) => process.stdout.write(line + '\n'),
+    onLine: (cb) => rl.on('line', cb),
+    close: () => rl.close(),
+  };
+}
+
+function respond(io: McpIo, id: unknown, result: unknown) {
+  io.writeLine(JSON.stringify({ jsonrpc: '2.0', id, result }));
+}
+
+/** 启动 MCP 服务（io 注入便于测试）。返回 stop 句柄。 */
+export function startMcpServer(io: McpIo, tasksFile: string = 'data/tasks.json') {
+  const service = new TaskService({ store: createFileTaskStore(tasksFile), defaultProjectId: () => 'default' });
+  const handlers = buildMcpToolHandlers(service);
+
+  io.onLine((line) => {
+    let msg: { id?: unknown; method?: string; params?: Record<string, unknown> };
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      return; // 非 JSON 行忽略（不打断连接）
+    }
+    const { id, method, params } = msg;
+    if (method === 'initialize') {
+      respond(io, id, {
+        protocolVersion: '2024-11-05',
+        capabilities: { tools: {} },
+        serverInfo: { name: 'doubao-mcp', version: '0.1.0' },
+      });
+    } else if (method === 'tools/list') {
+      respond(io, id, { tools: DOUBAO_MCP_TOOLS.map((t) => ({ ...t })) });
+    } else if (method === 'tools/call') {
+      const toolName = params?.name as keyof ReturnType<typeof buildMcpToolHandlers>;
+      const toolArgs = (params?.arguments ?? {}) as never;
+      const handler = handlers[toolName];
+      if (!handler) {
+        respond(io, id, { content: [{ type: 'text', text: JSON.stringify({ ok: false, error: 'UNKNOWN_TOOL' }) }], isError: true });
+      } else {
+        respond(io, id, handler(toolArgs));
+      }
+    } else if (method === 'ping') {
+      respond(io, id, {});
+    }
+    // 未知方法静默忽略（MCP 允许客户端扩展）
+  });
+
+  return { stop: () => io.close() };
+}
+
+// 仅直接执行时启动 stdio 服务
+const isDirect = typeof require !== 'undefined' && require.main === module;
+if (isDirect) {
+  const tasksFileArg = process.argv.find((a) => a.startsWith('--tasks-file='));
+  const tasksFile = tasksFileArg ? tasksFileArg.split('=')[1] : 'data/tasks.json';
+  startMcpServer(createStdioIo(), tasksFile);
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "validate": "pnpm run ts-check && pnpm run lint && pnpm run check:project && pnpm run test && pnpm run build"
+    "validate": "pnpm run ts-check && pnpm run lint && pnpm run check:project && pnpm run test && pnpm run build",
+    "cli:list": "node dist/main/cli/doubaoCliEntry.js list",
+    "mcp:server": "node dist/main/mcp/doubaoMcpServer.js"
   },
   "dependencies": {
     "@ant-design/icons": "^5.5.0",

--- a/tests/unit/cli-mcp-entry.test.ts
+++ b/tests/unit/cli-mcp-entry.test.ts
@@ -1,0 +1,122 @@
+/**
+ * DOUBAO-CLI-WIRING-01 契约测试：CLI/MCP 可执行入口接线。
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, readFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runCli } from '../../main/cli/doubaoCliEntry';
+import { startMcpServer, type McpIo } from '../../main/mcp/doubaoMcpServer';
+import type { Task } from '@doubao-studio/contracts';
+
+function fixtureTask(id: string, status: string): Task {
+  return {
+    id,
+    prompt: `任务 ${id}`,
+    assignedAccountId: null,
+    status,
+    mode: 'txt2img',
+    result: null,
+    outputs: status === 'done' ? ['file://out/1.png'] : [],
+    artifacts: [],
+    createdAt: '2026-08-16T00:00:00Z',
+    updatedAt: '2026-08-16T00:00:00Z',
+  } as unknown as Task;
+}
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'doubao-cli-'));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('CLI 入口接线', () => {
+  it('list：读取 JSON 任务文件并输出稳定 JSON（exit 0）', () => {
+    const file = join(dir, 'tasks.json');
+    writeFileSync(file, JSON.stringify([fixtureTask('a', 'queued'), fixtureTask('b', 'done')]), 'utf8');
+    const out: string[] = [];
+    const result = runCli(['list', '--tasks-file', file], (s) => out.push(s));
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(out[0]);
+    expect(parsed.ok).toBe(true);
+    expect((parsed.data as { id: string }[]).map((t) => t.id).sort()).toEqual(['a', 'b']);
+  });
+
+  it('task：不存在任务 exit 1 + TASK_NOT_FOUND', () => {
+    const file = join(dir, 'tasks.json');
+    writeFileSync(file, '[]', 'utf8');
+    const out: string[] = [];
+    const result = runCli(['task', 'nope', '--tasks-file', file], (s) => out.push(s));
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(out[0]).error).toBe('TASK_NOT_FOUND');
+  });
+
+  it('outputs/diagnostics 命令可用且零写入', () => {
+    const file = join(dir, 'tasks.json');
+    writeFileSync(file, JSON.stringify([fixtureTask('d', 'done')]), 'utf8');
+    const out1: string[] = [];
+    expect(runCli(['outputs', '--tasks-file', file], (s) => out1.push(s)).exitCode).toBe(0);
+    expect((JSON.parse(out1[0]).data as { taskId: string }[])[0].taskId).toBe('d');
+    const out2: string[] = [];
+    expect(runCli(['diagnostics', '--tasks-file', file], (s) => out2.push(s)).exitCode).toBe(0);
+    expect((JSON.parse(out2[0]).data as Task[])[0].prompt).toContain('已脱敏');
+    // 零写入：replace 恒 false，文件内容不变
+    const after = JSON.parse(readFileSync(file, 'utf8'));
+    expect(after.length).toBe(1);
+  });
+});
+
+function fakeIo(): McpIo & { sent: string[]; emit: (line: string) => void } {
+  const sent: string[] = [];
+  const callbacks: Array<(line: string) => void> = [];
+  return {
+    sent,
+    writeLine: (line: string) => {
+      sent.push(line);
+    },
+    onLine: (cb) => callbacks.push(cb),
+    close: () => {},
+    emit: (line: string) => callbacks.forEach((cb) => cb(line)),
+  };
+}
+
+describe('MCP stdio 入口接线', () => {
+  it('initialize / tools/list / tools/call / ping 全协议', () => {
+    const file = join(dir, 'tasks.json');
+    writeFileSync(file, JSON.stringify([fixtureTask('a', 'queued')]), 'utf8');
+    const io = fakeIo();
+    startMcpServer(io, file);
+
+    io.emit(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' }));
+    const init = JSON.parse(io.sent[0]);
+    expect(init.result.protocolVersion).toBe('2024-11-05');
+
+    io.emit(JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }));
+    const tools = JSON.parse(io.sent[1]);
+    expect(tools.result.tools.map((t: { name: string }) => t.name)).toEqual(['doubao.list_tasks', 'doubao.get_task']);
+
+    io.emit(JSON.stringify({ jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'doubao.get_task', arguments: { taskId: 'a' } } }));
+    const call = JSON.parse(io.sent[2]);
+    expect(call.result.isError).toBe(false);
+    expect(JSON.parse(call.result.content[0].text).data.id).toBe('a');
+
+    io.emit(JSON.stringify({ jsonrpc: '2.0', id: 4, method: 'ping' }));
+    expect(JSON.parse(io.sent[3]).result).toEqual({});
+
+    io.emit('not-json');
+    expect(io.sent.length).toBe(4);
+  });
+
+  it('未知工具 → isError UNKNOWN_TOOL', () => {
+    const file = join(dir, 'tasks.json');
+    writeFileSync(file, '[]', 'utf8');
+    const io = fakeIo();
+    startMcpServer(io, file);
+    io.emit(JSON.stringify({ jsonrpc: '2.0', id: 5, method: 'tools/call', params: { name: 'nope' } }));
+    const call = JSON.parse(io.sent[0]);
+    expect(call.result.isError).toBe(true);
+    expect(JSON.parse(call.result.content[0].text).error).toBe('UNKNOWN_TOOL');
+  });
+});


### PR DESCRIPTION
D-SPRINT-03 B-1：接线包——CLI 可执行入口（list/task/outputs/diagnostics，零写入零 Electron）+ MCP stdio 服务器（JSON-RPC initialize/tools/list/tools/call/ping，未知工具 fail-closed）+ 5 测试；ts-check/eslint 0；编译冒烟通过。package.json 新增 cli:list / mcp:server 脚本。