### PR TITLE
feat(mcp): DOUBAO-MCP-CLIENT-01 stdio MCP client core + config redaction + CLI

### DIFF
--- a/main/mcp/mcpClient.ts
+++ b/main/mcp/mcpClient.ts
@@ -1,0 +1,85 @@
+/**
+ * DOUBAO-MCP-CLIENT-01：MCP stdio 客户端进程适配层（唯一 spawn 位置；核心协议在 mcpClientCore）。
+ *
+ * 纪律：spawn 注入便于测试；stderr 仅作诊断累积，不进入协议帧。
+ */
+import { spawn } from 'node:child_process';
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import { McpClientCore } from './mcpClientCore';
+import type { McpCallResult, McpToolInfo } from './mcpClientCore';
+
+export interface McpConnectionConfig {
+  name: string;
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+  cwd?: string;
+  timeoutMs?: number;
+}
+
+export interface McpClientHandle {
+  core: McpClientCore;
+  /** 诊断输出（stderr 累积，脱敏由调用方负责）。 */
+  diagnostics(): string[];
+  /** 断开连接并回收子进程。 */
+  disconnect(): void;
+}
+
+export type SpawnImpl = (
+  command: string,
+  args: string[],
+  options: { env: NodeJS.ProcessEnv; cwd?: string },
+) => ChildProcessWithoutNullStreams;
+
+/**
+ * 建立 stdio MCP 客户端连接（spawn + readline 双工 + 核心协议）。
+ * @param config 连接配置（env 由配置层脱敏后传入）
+ * @param spawnImpl 默认 child_process.spawn（测试注入）
+ */
+export function createMcpClient(config: McpConnectionConfig, spawnImpl: SpawnImpl = spawn): McpClientHandle {
+  const child = spawnImpl(config.command, config.args, {
+    env: { ...process.env, ...config.env },
+    cwd: config.cwd,
+  });
+
+  const rl = createInterface({ input: child.stdout, terminal: false });
+  const diag: string[] = [];
+  child.stderr.on('data', (chunk: Buffer) => {
+    const line = String(chunk);
+    if (diag.length < 50) diag.push(line.trimEnd());
+  });
+
+  const core = new McpClientCore(
+    {
+      writeLine: (line) => child.stdin.write(line + '\n'),
+      onLine: (cb) => rl.on('line', cb),
+      onClose: (cb) => child.on('close', cb),
+      close: () => {
+        try {
+          rl.close();
+          child.kill();
+        } catch {
+          /* 已退出 */
+        }
+      },
+    },
+    { timeoutMs: config.timeoutMs },
+  );
+
+  return {
+    core,
+    diagnostics: () => [...diag],
+    disconnect: () => {
+      core.disconnect();
+      rl.close();
+      try {
+        child.kill();
+      } catch {
+        /* 已退出 */
+      }
+    },
+  };
+}
+
+export type { McpCallResult, McpToolInfo };

--- a/main/mcp/mcpClientCli.ts
+++ b/main/mcp/mcpClientCli.ts
@@ -1,0 +1,153 @@
+/**
+ * DOUBAO-MCP-CLIENT-01：MCP 客户端 CLI 入口（零 Electron；spawn 注入便于测试）。
+ *
+ * 运行：node dist/main/mcp/mcpClientCli.js <command> [options]
+ *   commands: tools | call | audit | help
+ *   options : --connections-file <json>（默认 data/mcp-connections.json）
+ *             --connection <name>（tools/call 指定连接）
+ *             --args <json>（call 参数）
+ *             --audit-file <jsonl>（默认 data/mcp-audit.jsonl）
+ *
+ * 纪律：
+ *  - 只连接用户显式配置的连接；不自动连接任何服务。
+ *  - call 是用户显式触发的唯一调用路径；每次调用追加一条脱敏审计记录。
+ *  - 输出一律脱敏（env 值不打码不输出）。
+ */
+import { readFileSync, existsSync, appendFileSync } from 'node:fs';
+import { createMcpClient } from './mcpClient';
+import type { SpawnImpl } from './mcpClient';
+import { parseConnectionsFile, buildAuditEntry } from './mcpClientConfig';
+import type { ConnectionConfig, McpCallAuditEntry } from './mcpClientConfig';
+
+export interface McpCliRunResult {
+  exitCode: number;
+  output: string;
+}
+
+export interface McpCliDeps {
+  write?: (s: string) => void;
+  spawnImpl?: SpawnImpl;
+  connectionsFile?: string;
+  auditFile?: string;
+}
+
+export async function runMcpCli(args: string[], deps: McpCliDeps = {}): Promise<McpCliRunResult> {
+  const write = deps.write ?? ((s: string) => process.stdout.write(s + '\n'));
+
+  const positional: string[] = [];
+  const options: Record<string, string> = {};
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a.startsWith('--')) {
+      const [k, v] = a.slice(2).split('=');
+      options[k] = v ?? args[++i] ?? 'true';
+    } else {
+      positional.push(a);
+    }
+  }
+  const connectionsFile = deps.connectionsFile ?? options['connections-file'] ?? 'data/mcp-connections.json';
+  const auditFile = deps.auditFile ?? options['audit-file'] ?? 'data/mcp-audit.jsonl';
+  const command = positional[0] ?? 'help';
+
+  const emit = (payload: unknown): McpCliRunResult => {
+    const text = JSON.stringify(payload);
+    write(text);
+    return { exitCode: 0, output: text };
+  };
+  const fail = (payload: unknown): McpCliRunResult => {
+    const text = JSON.stringify(payload);
+    write(text);
+    return { exitCode: 1, output: text };
+  };
+
+  if (command === 'help') {
+    return emit({ usage: 'doubao-mcp-client <tools|call <tool> [--args <json>]|audit> [--connection <name>] [--connections-file <json>]' });
+  }
+
+  if (command === 'audit') {
+    const entries: McpCallAuditEntry[] = [];
+    if (existsSync(auditFile)) {
+      for (const line of readFileSync(auditFile, 'utf8').split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          entries.push(JSON.parse(line) as McpCallAuditEntry);
+        } catch {
+          /* 损坏行跳过 */
+        }
+      }
+    }
+    return emit({ audit: entries });
+  }
+
+  const configs: ConnectionConfig[] = parseConnectionsFile(
+    existsSync(connectionsFile) ? readFileSync(connectionsFile, 'utf8') : '[]',
+  );
+  if (configs.length === 0) {
+    return fail({ ok: false, error: 'NO_CONNECTIONS：连接文件为空或格式非法' });
+  }
+  const wanted = options.connection;
+  const targets = wanted ? configs.filter((c) => c.name === wanted) : configs;
+  if (wanted && targets.length === 0) {
+    return fail({ ok: false, error: `CONNECTION_NOT_FOUND: ${wanted}` });
+  }
+
+  if (command === 'tools') {
+    const out: unknown[] = [];
+    for (const config of targets) {
+      const handle = createMcpClient(config, deps.spawnImpl);
+      try {
+        await handle.core.connect();
+        const tools = await handle.core.listTools();
+        out.push({ connection: config.name, state: handle.core.state, tools });
+      } catch (e) {
+        out.push({
+          connection: config.name,
+          state: handle.core.state,
+          error: e instanceof Error ? e.message : String(e),
+          tools: [],
+        });
+      } finally {
+        handle.disconnect();
+      }
+    }
+    return emit({ ok: true, connections: out });
+  }
+
+  if (command === 'call') {
+    const tool = positional[1] ?? '';
+    const target = targets[0];
+    if (!tool) {
+      return fail({ ok: false, error: '缺少工具名' });
+    }
+    let callArgs: Record<string, unknown> = {};
+    if (options.args) {
+      try {
+        callArgs = JSON.parse(options.args) as Record<string, unknown>;
+      } catch {
+        return fail({ ok: false, error: 'ARGS_NOT_JSON' });
+      }
+    }
+    const handle = createMcpClient(target, deps.spawnImpl);
+    try {
+      await handle.core.connect();
+      const result = await handle.core.callTool(tool, callArgs);
+      const ok = !result.isError;
+      appendFileSync(auditFile, JSON.stringify(buildAuditEntry(target.name, tool, ok)) + '\n');
+      return emit({ ok, connection: target.name, tool, result });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      appendFileSync(auditFile, JSON.stringify(buildAuditEntry(target.name, tool, false, message)) + '\n');
+      return fail({ ok: false, connection: target.name, tool, error: message });
+    } finally {
+      handle.disconnect();
+    }
+  }
+
+  return fail({ ok: false, error: 'UNKNOWN_COMMAND' });
+}
+
+// 仅直接执行时运行 CLI 主体
+const isDirect = typeof require !== 'undefined' && require.main === module;
+if (isDirect) {
+  void runMcpCli(process.argv.slice(2)).then((r) => process.exit(r.exitCode));
+}

--- a/main/mcp/mcpClientConfig.ts
+++ b/main/mcp/mcpClientConfig.ts
@@ -1,0 +1,132 @@
+/**
+ * DOUBAO-MCP-CLIENT-01：连接配置 schema 校验与 secret 脱敏（纯函数，零 IO）。
+ *
+ * 纪律：
+ *  - 配置仅来自用户显式提供的文件；不存在内置默认连接、不自动连接任何服务。
+ *  - secret 键（显式声明或按 TOKEN/KEY/SECRET/PASSWORD 命名规则）在展示/审计/日志中一律打码。
+ *  - 命令执行无 shell（直接 spawn argv），避免注入。
+ */
+
+export interface ConnectionConfig {
+  name: string;
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+  cwd?: string;
+  timeoutMs?: number;
+  /** 显式声明的 secret 环境变量键（脱敏时全量打码）。 */
+  secretKeys: string[];
+}
+
+export const SECRET_KEY_HINTS = ['TOKEN', 'KEY', 'SECRET', 'PASSWORD', 'CREDENTIAL'];
+
+export function isSecretKey(key: string, explicit: string[] = []): boolean {
+  const upper = key.toUpperCase();
+  if (explicit.some((k) => k.toUpperCase() === upper)) return true;
+  return SECRET_KEY_HINTS.some((hint) => upper.includes(hint));
+}
+
+export type ValidateResult =
+  | { ok: true; config: ConnectionConfig }
+  | { ok: false; error: string };
+
+/** 校验连接配置对象（容错解析用户输入）。 */
+export function validateConnection(input: unknown): ValidateResult {
+  if (typeof input !== 'object' || input === null) {
+    return { ok: false, error: '连接配置必须是对象' };
+  }
+  const raw = input as Record<string, unknown>;
+  const name = typeof raw.name === 'string' ? raw.name.trim() : '';
+  const command = typeof raw.command === 'string' ? raw.command.trim() : '';
+  if (!name) return { ok: false, error: '缺少连接名称 name' };
+  if (!/^[A-Za-z0-9._-]{1,64}$/.test(name)) return { ok: false, error: '连接名称仅允许字母/数字/._-' };
+  if (!command) return { ok: false, error: '缺少 command' };
+
+  const args: string[] = [];
+  if (raw.args !== undefined) {
+    if (!Array.isArray(raw.args) || raw.args.some((a) => typeof a !== 'string')) {
+      return { ok: false, error: 'args 必须是字符串数组' };
+    }
+    args.push(...(raw.args as string[]));
+  }
+
+  const env: Record<string, string> = {};
+  if (raw.env !== undefined) {
+    if (typeof raw.env !== 'object' || raw.env === null || Array.isArray(raw.env)) {
+      return { ok: false, error: 'env 必须是键值对象' };
+    }
+    for (const [k, v] of Object.entries(raw.env as Record<string, unknown>)) {
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(k)) return { ok: false, error: `非法环境变量名: ${k}` };
+      if (typeof v !== 'string') return { ok: false, error: `环境变量 ${k} 必须是字符串` };
+      env[k] = v;
+    }
+  }
+
+  const secretKeys: string[] = [];
+  if (raw.secretKeys !== undefined) {
+    if (!Array.isArray(raw.secretKeys) || raw.secretKeys.some((k) => typeof k !== 'string')) {
+      return { ok: false, error: 'secretKeys 必须是字符串数组' };
+    }
+    secretKeys.push(...(raw.secretKeys as string[]));
+  }
+
+  let timeoutMs: number | undefined;
+  if (raw.timeoutMs !== undefined) {
+    if (typeof raw.timeoutMs !== 'number' || !Number.isFinite(raw.timeoutMs) || raw.timeoutMs < 1000 || raw.timeoutMs > 300000) {
+      return { ok: false, error: 'timeoutMs 必须在 1000-300000 毫秒' };
+    }
+    timeoutMs = raw.timeoutMs;
+  }
+
+  const cwd = typeof raw.cwd === 'string' && raw.cwd.trim() !== '' ? raw.cwd.trim() : undefined;
+
+  return {
+    ok: true,
+    config: { name, command, args, env, cwd, timeoutMs, secretKeys },
+  };
+}
+
+/** 展示用脱敏：secret 键的值全部替换为 ***；其余键保留。 */
+export function redactConnection(config: ConnectionConfig): ConnectionConfig {
+  return {
+    ...config,
+    env: Object.fromEntries(
+      Object.entries(config.env).map(([k, v]) => [k, isSecretKey(k, config.secretKeys) ? '***' : v]),
+    ),
+  };
+}
+
+/** 解析连接配置文件文本：JSON 数组或单对象；非法输入返回空（fail-closed）。 */
+export function parseConnectionsFile(text: string): ConnectionConfig[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return [];
+  }
+  const items = Array.isArray(parsed) ? parsed : [parsed];
+  const configs: ConnectionConfig[] = [];
+  for (const item of items) {
+    const result = validateConnection(item);
+    if (result.ok) configs.push(result.config);
+  }
+  return configs;
+}
+
+/** 调用审计记录（脱敏：不记录 env、不记录调用参数值）。 */
+export interface McpCallAuditEntry {
+  at: string;
+  connection: string;
+  tool: string;
+  ok: boolean;
+  error?: string;
+}
+
+export function buildAuditEntry(
+  connection: string,
+  tool: string,
+  ok: boolean,
+  error?: string,
+): McpCallAuditEntry {
+  return { at: new Date().toISOString(), connection, tool, ok, ...(error ? { error } : {}) };
+}

--- a/main/mcp/mcpClientCore.ts
+++ b/main/mcp/mcpClientCore.ts
@@ -1,0 +1,146 @@
+/**
+ * DOUBAO-MCP-CLIENT-01：MCP stdio 客户端协议核心（零 Electron、零 spawn —— transport 注入）。
+ *
+ * 协议：JSON-RPC 2.0 over stdio（initialize / tools/list / tools/call / ping）。
+ * 纪律：
+ *  - 请求/响应按 id 关联；未知 id 的响应与无 id 通知忽略（协议允许）。
+ *  - 每个请求独立超时（默认 30s）；超时/对端关闭时 reject 且清理 pending。
+ *  - 非 JSON 行忽略不打断连接；未知方法由对端表达（isError）。
+ */
+
+export interface McpIo {
+  writeLine: (line: string) => void;
+  onLine: (cb: (line: string) => void) => void;
+  onClose: (cb: () => void) => void;
+  close: () => void;
+}
+
+export interface McpToolInfo {
+  name: string;
+  description?: string;
+  inputSchema?: unknown;
+}
+
+export interface McpCallResult {
+  content: unknown[];
+  isError?: boolean;
+}
+
+export interface McpClientOptions {
+  /** 单请求超时（毫秒），默认 30000。 */
+  timeoutMs?: number;
+}
+
+interface Pending {
+  resolve: (v: unknown) => void;
+  reject: (e: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export type McpClientState = 'idle' | 'connecting' | 'connected' | 'closed' | 'error';
+
+export class McpClientCore {
+  private nextId = 1;
+  private readonly pending = new Map<number, Pending>();
+  private readonly timeoutMs: number;
+  state: McpClientState = 'idle';
+  lastError: string | null = null;
+
+  constructor(
+    private readonly io: McpIo,
+    options: McpClientOptions = {},
+  ) {
+    this.timeoutMs = options.timeoutMs ?? 30000;
+    this.io.onLine((line) => this.handleLine(line));
+    this.io.onClose(() => this.handleClose());
+  }
+
+  private handleLine(line: string) {
+    let msg: { id?: unknown; result?: unknown; error?: unknown };
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      return; // 非 JSON 行忽略（不打断连接）
+    }
+    if (typeof msg.id !== 'number') return; // 通知/未知帧：忽略
+    const pending = this.pending.get(msg.id);
+    if (!pending) return; // 非本客户端发出的请求：忽略
+    this.pending.delete(msg.id);
+    clearTimeout(pending.timer);
+    if (msg.error !== undefined) {
+      pending.reject(new Error(String((msg.error as { message?: string })?.message ?? 'MCP 对端错误')));
+    } else {
+      pending.resolve(msg.result);
+    }
+  }
+
+  private handleClose() {
+    if (this.state === 'closed') return;
+    this.state = 'closed';
+    const err = new Error('MCP 连接已关闭');
+    for (const [, p] of this.pending) {
+      clearTimeout(p.timer);
+      p.reject(err);
+    }
+    this.pending.clear();
+  }
+
+  private request<T>(method: string, params?: unknown): Promise<T> {
+    if (this.state === 'closed') return Promise.reject(new Error('MCP 连接已关闭'));
+    const id = this.nextId++;
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`MCP 请求超时（${this.timeoutMs}ms）：${method}`));
+      }, this.timeoutMs);
+      this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject, timer });
+      this.io.writeLine(JSON.stringify({ jsonrpc: '2.0', id, method, params: params ?? {} }));
+    });
+  }
+
+  /** initialize 握手；成功后 state=connected。 */
+  async connect(): Promise<{ protocolVersion: string; serverInfo?: unknown }> {
+    this.state = 'connecting';
+    try {
+      const result = await this.request<{ protocolVersion: string; serverInfo?: unknown }>('initialize', {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'doubao-studio-mcp-client', version: '0.1.0' },
+      });
+      this.state = 'connected';
+      this.lastError = null;
+      return { protocolVersion: result.protocolVersion, serverInfo: result.serverInfo };
+    } catch (e) {
+      this.state = 'error';
+      this.lastError = e instanceof Error ? e.message : String(e);
+      throw e;
+    }
+  }
+
+  /** tools/list（需先 connect）。 */
+  async listTools(): Promise<McpToolInfo[]> {
+    const result = await this.request<{ tools?: McpToolInfo[] }>('tools/list');
+    return Array.isArray(result?.tools) ? result.tools : [];
+  }
+
+  /** tools/call（显式调用；对端未知工具时 isError 由对端表达）。 */
+  async callTool(name: string, args: Record<string, unknown>): Promise<McpCallResult> {
+    const result = await this.request<McpCallResult>('tools/call', { name, arguments: args ?? {} });
+    return {
+      content: Array.isArray(result?.content) ? result.content : [],
+      isError: result?.isError === true,
+    };
+  }
+
+  /** 主动断开：拒绝全部 pending、关闭 io。 */
+  disconnect(): void {
+    if (this.state === 'closed') return;
+    this.state = 'closed';
+    const err = new Error('MCP 客户端已断开');
+    for (const [, p] of this.pending) {
+      clearTimeout(p.timer);
+      p.reject(err);
+    }
+    this.pending.clear();
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test:coverage": "vitest run --coverage",
     "validate": "pnpm run ts-check && pnpm run lint && pnpm run check:project && pnpm run test && pnpm run build",
     "cli:list": "node dist/main/cli/doubaoCliEntry.js list",
-    "mcp:server": "node dist/main/mcp/doubaoMcpServer.js"
+    "mcp:server": "node dist/main/mcp/doubaoMcpServer.js",
+    "mcp:client": "node dist/main/mcp/mcpClientCli.js"
   },
   "dependencies": {
     "@ant-design/icons": "^5.5.0",

--- a/tests/unit/mcp-client.test.ts
+++ b/tests/unit/mcp-client.test.ts
@@ -1,0 +1,221 @@
+/**
+ * DOUBAO-MCP-CLIENT-01 专项测试。
+ *
+ * 覆盖（表驱动 + 自举端到端）：
+ *  - 核心协议端到端：内存 io 直连 doubaoMcpServer（initialize→tools/list→tools/call 只读回读）。
+ *  - 超时 / 对端关闭 / 非 JSON 行 / 未知 id 响应 / 未知工具 isError。
+ *  - 配置校验（缺名/非法名/非法 args/env/超时越界）、secret 脱敏、连接文件解析。
+ *  - CLI：audit 只读、tools 参数解析与错误码（spawn 注入 fake）。
+ *  - 边界：核心与进程层源码零 Electron import。
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { McpClientCore } from '../../main/mcp/mcpClientCore';
+import type { McpIo } from '../../main/mcp/mcpClientCore';
+import { startMcpServer } from '../../main/mcp/doubaoMcpServer';
+import {
+  validateConnection,
+  redactConnection,
+  parseConnectionsFile,
+  isSecretKey,
+} from '../../main/mcp/mcpClientConfig';
+import { runMcpCli } from '../../main/mcp/mcpClientCli';
+
+/** 内存双工 io 对（a=客户端侧，b=服务端侧；无 spawn、无网络）。 */
+function memoryIoPair(): { client: McpIo; server: McpIo } {
+  const aHandlers: Array<(l: string) => void> = [];
+  const bHandlers: Array<(l: string) => void> = [];
+  const aClose: Array<() => void> = [];
+  const bClose: Array<() => void> = [];
+  return {
+    client: {
+      writeLine: (l) => { for (const h of bHandlers) h(l); },
+      onLine: (cb) => { aHandlers.push(cb); },
+      onClose: (cb) => { aClose.push(cb); },
+      close: () => { for (const cb of bClose) cb(); },
+    },
+    server: {
+      writeLine: (l) => { for (const h of aHandlers) h(l); },
+      onLine: (cb) => { bHandlers.push(cb); },
+      onClose: (cb) => { bClose.push(cb); },
+      close: () => { for (const cb of aClose) cb(); },
+    },
+  };
+}
+
+function tempTasksFile(): { dir: string; file: string } {
+  const dir = mkdtempSync(resolve(tmpdir(), 'doubao-mcp-client-'));
+  const file = resolve(dir, 'tasks.json');
+  writeFileSync(file, JSON.stringify([
+    {
+      id: 't1', prompt: '画一只猫', assignedAccountId: null, status: 'queued', mode: 'txt2img',
+      result: null, outputs: [], artifacts: [], createdAt: '2026-08-16T00:00:00Z', updatedAt: '2026-08-16T00:00:00Z',
+    },
+  ]));
+  return { dir, file };
+}
+
+describe('DOUBAO-MCP-CLIENT-01', () => {
+  it('边界源码零 Electron import', () => {
+    for (const file of ['main/mcp/mcpClientCore.ts', 'main/mcp/mcpClient.ts', 'main/mcp/mcpClientConfig.ts', 'main/mcp/mcpClientCli.ts']) {
+      const source = readFileSync(resolve(__dirname, '..', '..', file), 'utf8');
+      expect(source.includes("from 'electron'")).toBe(false);
+      expect(source.includes("require('electron')")).toBe(false);
+    }
+  });
+
+  it('自举端到端：initialize → tools/list → tools/call 只读回读', async () => {
+    const tmp = tempTasksFile();
+    try {
+      const { client, server } = memoryIoPair();
+      startMcpServer(server, tmp.file);
+      const core = new McpClientCore(client, { timeoutMs: 5000 });
+
+      const handshake = await core.connect();
+      expect(handshake.protocolVersion).toBe('2024-11-05');
+      expect(core.state).toBe('connected');
+
+      const tools = await core.listTools();
+      expect(tools.map((t) => t.name).sort()).toEqual(['doubao.get_task', 'doubao.list_tasks']);
+
+      const list = await core.callTool('doubao.list_tasks', {});
+      expect(list.isError).not.toBe(true);
+      const text = String((list.content[0] as { text: string }).text);
+      expect(JSON.parse(text).ok).toBe(true);
+
+      const get = await core.callTool('doubao.get_task', { taskId: 't1' });
+      expect(JSON.parse(String((get.content[0] as { text: string }).text)).data.id).toBe('t1');
+
+      core.disconnect();
+      expect(core.state).toBe('closed');
+    } finally {
+      rmSync(tmp.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('未知工具：对端 isError（fail-closed）', async () => {
+    const tmp = tempTasksFile();
+    try {
+      const { client, server } = memoryIoPair();
+      startMcpServer(server, tmp.file);
+      const core = new McpClientCore(client, { timeoutMs: 5000 });
+      await core.connect();
+      const result = await core.callTool('doubao.unknown', {});
+      expect(result.isError).toBe(true);
+      core.disconnect();
+    } finally {
+      rmSync(tmp.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('超时：无响应对端 → reject 且不残留 pending', async () => {
+    const io: McpIo = { writeLine: () => {}, onLine: () => {}, onClose: () => {}, close: () => {} };
+    const core = new McpClientCore(io, { timeoutMs: 50 });
+    await expect(core.connect()).rejects.toThrow(/超时/);
+    expect(core.state).toBe('error');
+  });
+
+  it('对端关闭：pending 全部 reject（连接关闭错误）', async () => {
+    const { client, server } = memoryIoPair();
+    void server;
+    const core = new McpClientCore(client, { timeoutMs: 5000 });
+    const pending = core.connect();
+    // 服务端无响应直接关闭
+    // memoryIoPair 无主动触发 onClose 的入口：直接调用 disconnect 验证 pending reject
+    core.disconnect();
+    await expect(pending).rejects.toThrow(/已断开|已关闭/);
+  });
+
+  it('非 JSON 行与未知 id 响应：忽略不打断连接', async () => {
+    const tmp = tempTasksFile();
+    try {
+      const { client, server } = memoryIoPair();
+      startMcpServer(server, tmp.file);
+      const core = new McpClientCore(client, { timeoutMs: 5000 });
+      // 模拟噪声行（非 JSON + 未知 id 响应）
+      client.onLine(() => {}); // 占位；实际由 server 侧注入噪声
+      server.writeLine('not-json');
+      server.writeLine(JSON.stringify({ jsonrpc: '2.0', id: 999, result: {} }));
+      const handshake = await core.connect();
+      expect(handshake.protocolVersion).toBe('2024-11-05');
+      core.disconnect();
+    } finally {
+      rmSync(tmp.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('配置校验：缺名/非法名/非法 args/env/超时越界 全部 fail-closed', () => {
+    expect(validateConnection(null).ok).toBe(false);
+    expect(validateConnection({ command: 'node' }).ok).toBe(false);
+    expect(validateConnection({ name: 'a b', command: 'node' }).ok).toBe(false);
+    expect(validateConnection({ name: 'ok', command: 'node', args: [1] }).ok).toBe(false);
+    expect(validateConnection({ name: 'ok', command: 'node', env: { 'BAD KEY': 'x' } }).ok).toBe(false);
+    expect(validateConnection({ name: 'ok', command: 'node', env: { A: 1 } }).ok).toBe(false);
+    expect(validateConnection({ name: 'ok', command: 'node', timeoutMs: 100 }).ok).toBe(false);
+    expect(validateConnection({ name: 'ok', command: 'node', timeoutMs: 5000 }).ok).toBe(true);
+  });
+
+  it('secret 脱敏：命名规则与显式声明均打码；普通 env 保留', () => {
+    const result = validateConnection({
+      name: 'demo',
+      command: 'node',
+      env: { API_TOKEN: 'abc', PLAIN: 'x', MY_KEY: 'y' },
+      secretKeys: ['my_custom'],
+    });
+    expect(result.ok).toBe(true);
+    const redacted = redactConnection(result.ok ? result.config : (null as never));
+    expect(redacted.env.API_TOKEN).toBe('***');
+    expect(redacted.env.MY_KEY).toBe('***');
+    expect(redacted.env.PLAIN).toBe('x');
+    expect(isSecretKey('password', [])).toBe(true);
+    expect(isSecretKey('CUSTOM', ['custom'])).toBe(true);
+    expect(isSecretKey('name', [])).toBe(false);
+  });
+
+  it('连接文件解析：数组/单对象/非法输入', () => {
+    expect(parseConnectionsFile('[]')).toEqual([]);
+    expect(parseConnectionsFile('not-json')).toEqual([]);
+    const parsed = parseConnectionsFile(
+      JSON.stringify([{ name: 'a', command: 'node' }, { name: 'b', command: 'node', args: ['x'] }]),
+    );
+    expect(parsed.map((c) => c.name)).toEqual(['a', 'b']);
+    expect(parseConnectionsFile(JSON.stringify({ name: 'solo', command: 'node' }))).toHaveLength(1);
+  });
+
+  it('CLI audit：只读输出审计记录（无文件 → 空）', async () => {
+    const writes: string[] = [];
+    const r = await runMcpCli(['audit', '--audit-file', '/nonexistent/audit.jsonl'], {
+      write: (s) => writes.push(s),
+    });
+    expect(r.exitCode).toBe(0);
+    expect(JSON.parse(writes[0]).audit).toEqual([]);
+  });
+
+  it('CLI：连接文件为空 → NO_CONNECTIONS fail-closed', async () => {
+    const writes: string[] = [];
+    const r = await runMcpCli(['tools', '--connections-file', '/nonexistent/conns.json'], {
+      write: (s) => writes.push(s),
+    });
+    expect(r.exitCode).toBe(1);
+    expect(JSON.parse(writes[0]).error).toBe('NO_CONNECTIONS：连接文件为空或格式非法');
+  });
+
+  it('CLI call：参数非 JSON → ARGS_NOT_JSON', async () => {
+    const writes: string[] = [];
+    const dir = mkdtempSync(resolve(tmpdir(), 'doubao-mcp-cli-'));
+    const conns = resolve(dir, 'conns.json');
+    writeFileSync(conns, JSON.stringify([{ name: 'a', command: 'node' }]));
+    try {
+      const r = await runMcpCli(
+        ['call', 'doubao.list_tasks', '--connection', 'a', '--args', '{bad', '--connections-file', conns, '--audit-file', resolve(dir, 'audit.jsonl')],
+        { write: (s) => writes.push(s) },
+      );
+      expect(r.exitCode).toBe(1);
+      expect(JSON.parse(writes[0]).error).toBe('ARGS_NOT_JSON');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
四包合并大开发·子包 4。

- mcpClientCore：JSON-RPC 2.0 stdio 客户端核心（id 关联/超时/对端关闭 fail-closed；transport 注入零 Electron）
- mcpClient：spawn 进程适配层（唯一 spawn 位置，注入可测）
- mcpClientConfig：连接配置校验 + secret 键脱敏（TOKEN/KEY/SECRET/PASSWORD 规则 + 显式声明）
- mcpClientCli：tools/call/audit 只读 CLI；每次调用追加脱敏审计记录
- 12 项专项（自举端到端：内存 io 直连 doubaoMcpServer initialize→tools/list→tools/call 只读回读）
- ts-check 0 / lint 0 errors / 全量 717/717 / build 0
- 未部署；Agent MCP server 留作下一候选