### PR TITLE
feat(experimental): direct source extraction fallback (opt-in, user-authorized)

### DIFF
--- a/src/components/BrowserPanel.tsx
+++ b/src/components/BrowserPanel.tsx
@@ -9,7 +9,7 @@
  */
 
 import React, { useRef, useEffect, useCallback, useState } from 'react';
-import { message, Tooltip } from 'antd';
+import { message, Tooltip, Switch, Modal } from 'antd';
 import type { Account, Task, TaskUpdateInput } from '../types';
 import { useAccountStore } from '../store/useAccountStore';
 import { useTaskStore } from '../store/useTaskStore';
@@ -18,6 +18,7 @@ import { classifyTaskError } from '../utils/taskRuntime';
 import { evaluateVideoCapability, isRestrictionFailure } from '../utils/videoCapability';
 import { automationEngine } from '../automation/AutomationEngine';
 import { runAdapterSelfCheck } from '../automation/doubaoAdapter';
+import { isExperimentalNoWatermarkEnabled, setExperimentalNoWatermarkEnabled } from '../utils/experimentalNoWatermark';
 import {
   injectPrompt,
   submitPrompt,
@@ -52,6 +53,7 @@ const formatResolutionMessage = (result: VideoArtifactResolution): string => {
     captured_response: '已拦截响应',
     conversation_scan: '对话页面扫描',
     page_fallback: '页面回退地址',
+    experimental: '实验直取（未经官方授权）',
   };
   const statusLabels: Record<string, string> = {
     resolved: '已获取',
@@ -90,6 +92,31 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
   const [activeLoading, setActiveLoading] = useState(true);
   const [loadText, setLoadText] = useState('加载豆包中...');
   const [manualVideoExtracting, setManualVideoExtracting] = useState(false);
+  /** 实验开关（默认关闭；用户显式开启后，官方授权失败时尝试直接提取源文件） */
+  const [experimentalNoWatermark, setExperimentalNoWatermark] = useState<boolean>(() => isExperimentalNoWatermarkEnabled());
+
+  /** 切换实验开关：开启需二次确认（对抗平台能力，有账号风控风险）。 */
+  const toggleExperimentalNoWatermark = (enabled: boolean) => {
+    if (!enabled) {
+      setExperimentalNoWatermarkEnabled(false);
+      setExperimentalNoWatermark(false);
+      return;
+    }
+    Modal.confirm({
+      title: '开启实验模式：直接提取源文件？',
+      content:
+        '该模式在豆包官方未开放无水印下载时，尝试绕过官方授权直接提取源文件。' +
+        '风险：可能违反豆包服务条款、触发账号风控；提取结果可能仍含水印或无法播放。' +
+        '仅对手动提取生效，自动任务不受影响。确定开启？',
+      okText: '知晓风险，开启',
+      cancelText: '取消',
+      onOk: () => {
+        setExperimentalNoWatermarkEnabled(true);
+        setExperimentalNoWatermark(true);
+        message.warning('实验模式已开启：官方未授权时将以实验通道提取源文件（结果未经官方确认）');
+      },
+    });
+  };
 
   const accountBusy = useTaskStore((s) => s.accountBusy);
   const accountAutoState = useTaskStore((s) => s.accountAutomationState);
@@ -458,6 +485,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
           runId: task.runtime?.runId,
           timeoutMs: 15000,
           isManual: true,
+          experimentalNoWatermark: isExperimentalNoWatermarkEnabled(),
         });
         if (result.status === 'resolved' && result.url) {
           const outputs = normalizeVideoUrls([result.url]);
@@ -993,6 +1021,25 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
               <path d="M12 3v12m0 0 4-4m-4 4-4-4M5 21h14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
             </svg>
           </button>
+        </Tooltip>
+        <Tooltip
+          title={
+            experimentalNoWatermark
+              ? '实验模式已开启：官方未授权时将以实验通道提取源文件（有账号风控风险）'
+              : '实验模式（默认关闭）：官方未授权时尝试直接提取源文件，有账号风控风险'
+          }
+        >
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 2, marginLeft: 6 }}>
+            <Switch
+              size="small"
+              checked={experimentalNoWatermark}
+              onChange={toggleExperimentalNoWatermark}
+              style={{ transform: 'scale(0.8)' }}
+            />
+            <span style={{ fontSize: 10, color: experimentalNoWatermark ? '#f59e0b' : '#8a8f99', whiteSpace: 'nowrap' }}>
+              实验直取
+            </span>
+          </span>
         </Tooltip>
       </div>
 

--- a/src/utils/doubaoBridge.ts
+++ b/src/utils/doubaoBridge.ts
@@ -4245,6 +4245,7 @@ import {
   createResolvedResolution,
   createFailedResolution,
 } from './videoArtifactResolver';
+import { tryExperimentalDirectExtract } from './experimentalNoWatermark';
 
 /**
  * resolveVideoArtifact 的上下文参数。
@@ -4262,6 +4263,8 @@ export interface ResolveVideoArtifactContext {
   isManual?: boolean;
   /** 仅接受豆包官方明确确认的无水印下载地址 */
   requireWithoutWatermark?: boolean;
+  /** 实验开关：官方授权失败后尝试直接提取源文件（用户显式授权；默认关闭，候选标注 experimental） */
+  experimentalNoWatermark?: boolean;
   /** 可选的中断信号，取消后立即停止解析 */
   signal?: AbortSignal;
 }
@@ -4349,8 +4352,39 @@ export async function resolveVideoArtifact(
     attempts.push(fallbackResult.attempt);
   }
 
+  // ---- 策略 6（实验，默认关闭）：官方失败后直接提取源文件 ----
+  if (!isAborted() && ctx.experimentalNoWatermark) {
+    const expResult = await tryExperimentalStrategy(webview, resolvedVid, remainingMs());
+    candidates.push(...expResult.candidates);
+    attempts.push(expResult.attempt);
+  }
+
   // ---- 候选过滤、排序与选择 ----
   return selectBestCandidate(candidates, resolvedVid, ctx, attempts);
+}
+
+/**
+ * 策略 6（实验，默认关闭）：官方授权失败后直接提取源文件候选。
+ * 仅当 ctx.experimentalNoWatermark 且已有 vid 时执行；候选 source='experimental'，
+ * 标注未经官方授权（可能仍含水印/触发风控），由 selectBestCandidate 作为最后手段使用。
+ */
+async function tryExperimentalStrategy(
+  webview: WebviewHandle,
+  vid: string | undefined,
+  timeoutMs: number,
+): Promise<{ candidates: VideoCandidate[]; attempt: ArtifactAttempt }> {
+  if (!vid) {
+    return { candidates: [], attempt: { strategy: 'experimental', result: 'skip', reason: '无 vid' } };
+  }
+  try {
+    const candidates = await tryExperimentalDirectExtract(webview, vid, timeoutMs);
+    if (candidates.length === 0) {
+      return { candidates, attempt: { strategy: 'experimental', result: 'fail', reason: '未发现可用源文件地址' } };
+    }
+    return { candidates, attempt: { strategy: 'experimental', result: 'success', reason: `${candidates.length} 个实验候选（未经官方授权）` } };
+  } catch (err: unknown) {
+    return { candidates: [], attempt: { strategy: 'experimental', result: 'fail', reason: getErrorMessage(err) } };
+  }
 }
 
 /**
@@ -4602,11 +4636,17 @@ function selectBestCandidate(
     runId: ctx.runId,
   };
   const contextMatched = filterCandidatesByContext(candidates, filterCtx);
-  const filtered = ctx.requireWithoutWatermark
+  const officialFiltered = ctx.requireWithoutWatermark
     ? contextMatched.filter((candidate) => (
       candidate.source === 'platform_download_info' && candidate.isOriginal
     ))
     : contextMatched;
+  // 实验通道（默认关闭）：官方授权候选为空且显式开启时，把 experimental 候选作为最后手段参与选择。
+  // experimental 候选未经官方授权（可能仍含水印/触发风控），UI 必须明示来源。
+  let filtered = officialFiltered;
+  if (filtered.length === 0 && ctx.experimentalNoWatermark) {
+    filtered = contextMatched.filter((candidate) => candidate.source === 'experimental');
+  }
   const sorted = sortCandidatesByTrust(filtered);
 
   // 如果有多个原始地址候选且无法唯一匹配，标记需要人工选择
@@ -4642,8 +4682,13 @@ function selectBestCandidate(
       && attempt.reason?.includes('without_watermark=false')
     ))
     : undefined;
-  const lastError = officialWatermarkError ?? attempts.filter((a) => a.result === 'fail').pop();
-  const reason = lastError?.reason || '所有策略均未获取到视频地址';
+  const experimentalError = ctx.experimentalNoWatermark
+    ? attempts.find((attempt) => attempt.strategy === 'experimental' && attempt.result === 'fail')
+    : undefined;
+  const lastError = officialWatermarkError ?? experimentalError ?? attempts.filter((a) => a.result === 'fail').pop();
+  const reason = experimentalError
+    ? `${lastError?.reason || '官方未开放无水印'}；实验直取未获得可验证源文件（实验模式，可能仍含水印）`
+    : (lastError?.reason || '所有策略均未获取到视频地址');
   return createFailedResolution('unavailable', reason, attempts, resolvedVid);
 }
 

--- a/src/utils/experimentalNoWatermark.ts
+++ b/src/utils/experimentalNoWatermark.ts
@@ -1,0 +1,152 @@
+/**
+ * 实验：源文件直取（绕过官方无水印授权）——用户明确知情授权的对抗性实验功能。
+ *
+ * ⚠️ 风险与边界（必须遵守）：
+ *  - 本模块是用户授权下的实验性能力：默认关闭；仅在显式开启后生效。
+ *  - 平台可能校验服务端渲染水印：实验候选**不保证无水印**，下载结果由用户自行确认。
+ *  - 使用可能违反豆包服务条款并触发账号风控——仅对用户显式指定的账号操作，不用于自动任务。
+ *  - 官方授权通道（get_without_watermark / without_watermark=true）永远优先；
+ *    实验候选只作为官方拒绝后的最后手段，且结果明确标注 experimental。
+ */
+import type { VideoCandidate } from './videoArtifactResolver';
+
+const STORAGE_KEY = 'doubao.experimental.noWatermark.enabled';
+
+/** 实验开关（渲染层 localStorage；无 storage 环境默认关闭）。 */
+export function isExperimentalNoWatermarkEnabled(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function setExperimentalNoWatermarkEnabled(enabled: boolean): void {
+  try {
+    if (enabled) localStorage.setItem(STORAGE_KEY, '1');
+    else localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* storage 不可用时开关不持久化（保持默认关闭） */
+  }
+}
+
+/** 深度扫描任意响应对象中的候选媒体 URL（按键名优先级）。 */
+const URL_KEYS = ['no_watermark_url', 'download_url', 'main_url', 'main', 'play_url', 'url'];
+
+export function collectExperimentalUrls(data: unknown, depth = 0, seen = new Set<unknown>()): string[] {
+  if (depth > 5 || data === null || typeof data !== 'object' || seen.has(data)) return [];
+  seen.add(data);
+  const results: string[] = [];
+  if (Array.isArray(data)) {
+    for (const item of data) results.push(...collectExperimentalUrls(item, depth + 1, seen));
+    return results;
+  }
+  const obj = data as Record<string, unknown>;
+  for (const key of Object.keys(obj)) {
+    const value = obj[key];
+    if (URL_KEYS.includes(key) && typeof value === 'string' && /^https?:\/\//.test(value)) {
+      results.push(value);
+    } else {
+      results.push(...collectExperimentalUrls(value, depth + 1, seen));
+    }
+  }
+  return results;
+}
+
+/**
+ * URL 参数改写：把播放地址的 lr 参数替换为 video_gen_no_watermark。
+ * 注：8-13 热修验证该参数对当前平台可能无效（水印为服务端渲染）——实验候选，不保证效果。
+ */
+export function rewriteLrParam(url: string): string {
+  try {
+    const u = new URL(url);
+    const lr = u.searchParams.get('lr');
+    if (lr && lr !== 'video_gen_no_watermark') {
+      u.searchParams.set('lr', 'video_gen_no_watermark');
+      return u.toString();
+    }
+    if (!lr) {
+      u.searchParams.set('lr', 'video_gen_no_watermark');
+      return u.toString();
+    }
+    return url;
+  } catch {
+    return url;
+  }
+}
+
+/** webview 类型（最小面，避免依赖 electron 类型）。 */
+interface ExperimentalWebview {
+  executeJavaScript: (code: string) => Promise<unknown>;
+}
+
+/**
+ * 实验直取：无条件读取官方接口原始响应（不检查 without_watermark），
+ * 并从响应深度扫描候选地址；附带普通播放地址的参数改写候选。
+ */
+export async function tryExperimentalDirectExtract(
+  webview: ExperimentalWebview,
+  vid: string,
+  timeoutMs: number,
+): Promise<VideoCandidate[]> {
+  const candidates: VideoCandidate[] = [];
+  if (!vid) return candidates;
+
+  const code = `
+    (function() {
+      var vid = ${JSON.stringify(vid)};
+      var timeoutMs = ${timeoutMs};
+      function probe(path, body) {
+        var controller = new AbortController();
+        var timer = setTimeout(function() { controller.abort(); }, timeoutMs);
+        return fetch(path, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'origin': location.origin, 'referer': location.href },
+          credentials: 'include',
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        }).then(function(r) { return r.text().then(function(t) { return t; }); })
+          .catch(function() { return null; })
+          .finally(function() { clearTimeout(timer); });
+      }
+      return Promise.all([
+        probe('/creativity/resource/get_without_watermark', { vid: [vid] }),
+        probe('/samantha/media/get_play_info', { vid: vid }),
+      ]).then(function(responses) {
+        return responses.filter(Boolean);
+      });
+    })();
+  `;
+
+  let rawResponses: unknown;
+  try {
+    rawResponses = await webview.executeJavaScript(code);
+  } catch {
+    return candidates;
+  }
+  if (!Array.isArray(rawResponses)) return candidates;
+
+  const urls: string[] = [];
+  for (const raw of rawResponses) {
+    if (typeof raw !== 'string') continue;
+    try {
+      const parsed = JSON.parse(raw);
+      urls.push(...collectExperimentalUrls(parsed));
+    } catch {
+      /* 非 JSON 响应跳过 */
+    }
+  }
+  // 参数改写候选（对普通播放地址附加 lr=video_gen_no_watermark）
+  for (const url of urls) {
+    const rewritten = rewriteLrParam(url);
+    if (rewritten !== url) urls.push(rewritten);
+  }
+  // 去重（保持顺序）
+  const seen = new Set<string>();
+  for (const url of urls) {
+    if (seen.has(url)) continue;
+    seen.add(url);
+    candidates.push({ url, source: 'experimental', isOriginal: false, vid });
+  }
+  return candidates;
+}

--- a/src/utils/videoArtifactResolver.ts
+++ b/src/utils/videoArtifactResolver.ts
@@ -15,7 +15,8 @@ export type VideoArtifactSource =
   | 'play_info'                // get_play_info 接口返回的 original_media_info / download_url
   | 'captured_response'        // SSE 响应中拦截到的原始媒体地址
   | 'conversation_scan'        // 从对话/Thread 页面结构化数据中提取的地址
-  | 'page_fallback';           // 普通 DOM 结果 URL，非原始地址
+  | 'page_fallback'            // 普通 DOM 结果 URL，非原始地址
+  | 'experimental';            // 实验直取（用户显式授权；未经官方授权，可能仍含水印）
 
 /** 解析状态 */
 export type VideoArtifactStatus =
@@ -337,6 +338,7 @@ const SOURCE_PRIORITY: Record<VideoArtifactSource, number> = {
   captured_response: 2,
   conversation_scan: 3,
   page_fallback: 4,
+  experimental: 5, // 实验直取（未经官方授权）始终最低优先
 };
 
 /**

--- a/tests/unit/experimental-no-watermark.test.ts
+++ b/tests/unit/experimental-no-watermark.test.ts
@@ -1,0 +1,204 @@
+/**
+ * tests/unit/experimental-no-watermark.test.ts
+ *
+ * 实验通道（用户授权绕过官方无水印授权）专项测试：
+ *  - 开关默认关闭 / 持久化 / storage 不可用防御。
+ *  - collectExperimentalUrls 深度扫描与顺序去重。
+ *  - rewriteLrParam 参数改写边界。
+ *  - tryExperimentalDirectExtract：无条件读官方接口原始响应 → 候选提取 → 参数改写候选。
+ *  - 集成（resolveVideoArtifact）：开关关闭保持 fail-closed；开启后官方失败回退实验候选并标注来源。
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  isExperimentalNoWatermarkEnabled,
+  setExperimentalNoWatermarkEnabled,
+  collectExperimentalUrls,
+  rewriteLrParam,
+  tryExperimentalDirectExtract,
+} from '../../src/utils/experimentalNoWatermark';
+import { manualResolveVideoArtifact } from '../../src/utils/doubaoBridge';
+import type { WebviewHandle } from '../../src/utils/doubaoBridge';
+
+describe('实验通道开关', () => {
+  const storage = new Map<string, string>();
+  beforeEach(() => {
+    storage.clear();
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => storage.get(k) ?? null,
+      setItem: (k: string, v: string) => storage.set(k, v),
+      removeItem: (k: string) => storage.delete(k),
+    });
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('默认关闭；set(true) 后开启并持久化', () => {
+    expect(isExperimentalNoWatermarkEnabled()).toBe(false);
+    setExperimentalNoWatermarkEnabled(true);
+    expect(isExperimentalNoWatermarkEnabled()).toBe(true);
+    expect(storage.get('doubao.experimental.noWatermark.enabled')).toBe('1');
+    setExperimentalNoWatermarkEnabled(false);
+    expect(isExperimentalNoWatermarkEnabled()).toBe(false);
+  });
+
+  it('storage 不可用（异常）时默认关闭且不抛错', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => { throw new Error('denied'); },
+      setItem: () => { throw new Error('denied'); },
+      removeItem: () => { throw new Error('denied'); },
+    });
+    expect(isExperimentalNoWatermarkEnabled()).toBe(false);
+    expect(() => setExperimentalNoWatermarkEnabled(true)).not.toThrow();
+    expect(isExperimentalNoWatermarkEnabled()).toBe(false);
+  });
+});
+
+describe('collectExperimentalUrls 深度扫描', () => {
+  it('提取 no_watermark_url / download_url / main_url / 嵌套与数组', () => {
+    const data = {
+      code: 0,
+      data: {
+        without_watermark: false,
+        download_video: { vid1: { download_url: 'https://vod.example.com/a.mp4' } },
+        video_info: { main_url: 'https://vod.example.com/b.mp4' },
+        list: [{ no_watermark_url: 'https://vod.example.com/c.mp4' }],
+      },
+    };
+    const urls = collectExperimentalUrls(data);
+    expect(urls).toEqual([
+      'https://vod.example.com/a.mp4',
+      'https://vod.example.com/b.mp4',
+      'https://vod.example.com/c.mp4',
+    ]);
+  });
+
+  it('非法值（非 http、非字符串）跳过；深循环不崩溃', () => {
+    const cyclic: Record<string, unknown> = { url: 'not-a-url' };
+    cyclic.self = cyclic;
+    expect(collectExperimentalUrls({ a: cyclic, b: 1, c: null })).toEqual([]);
+  });
+});
+
+describe('rewriteLrParam 参数改写', () => {
+  it('已有 lr 参数 → 替换为 video_gen_no_watermark', () => {
+    expect(rewriteLrParam('https://vod.example.com/v.mp4?lr=abc&x=1')).toBe(
+      'https://vod.example.com/v.mp4?lr=video_gen_no_watermark&x=1',
+    );
+  });
+
+  it('无 lr 参数 → 追加', () => {
+    expect(rewriteLrParam('https://vod.example.com/v.mp4?x=1')).toBe(
+      'https://vod.example.com/v.mp4?x=1&lr=video_gen_no_watermark',
+    );
+  });
+
+  it('已是目标值或非法 URL → 原样返回', () => {
+    expect(rewriteLrParam('https://vod.example.com/v.mp4?lr=video_gen_no_watermark')).toBe(
+      'https://vod.example.com/v.mp4?lr=video_gen_no_watermark',
+    );
+    expect(rewriteLrParam('not-a-url')).toBe('not-a-url');
+  });
+});
+
+describe('tryExperimentalDirectExtract', () => {
+  const createWebview = (responses: unknown[] | null): WebviewHandle => ({
+    executeJavaScript: vi.fn(async (): Promise<unknown> => responses),
+    loadURL: vi.fn(),
+    getURL: vi.fn(() => 'https://www.doubao.com/chat/'),
+  });
+
+  it('官方响应带 download_url → 提取候选并附加参数改写候选（去重）', async () => {
+    const wm = JSON.stringify({
+      code: 0,
+      data: { without_watermark: false, download_video: { vid1: { download_url: 'https://vod.example.com/a.mp4?lr=wm1' } } },
+    });
+    const pi = JSON.stringify({ code: 0, data: { video_info: { no_watermark_url: 'https://vod.example.com/b.mp4' } } });
+    const candidates = await tryExperimentalDirectExtract(createWebview([wm, pi]), 'vid1', 5000);
+    const urls = candidates.map((c) => c.url);
+    expect(urls).toContain('https://vod.example.com/a.mp4?lr=video_gen_no_watermark');
+    expect(urls).toContain('https://vod.example.com/b.mp4');
+    expect(candidates.every((c) => c.source === 'experimental' && c.isOriginal === false && c.vid === 'vid1')).toBe(true);
+    expect(new Set(urls).size).toBe(urls.length);
+  });
+
+  it('无 vid → 空；执行抛错 → 空（fail-closed 不中断）', async () => {
+    expect(await tryExperimentalDirectExtract(createWebview([]), '', 1000)).toEqual([]);
+    const throwing: WebviewHandle = {
+      executeJavaScript: vi.fn(async () => { throw new Error('boom'); }),
+      loadURL: vi.fn(),
+      getURL: vi.fn(),
+    };
+    expect(await tryExperimentalDirectExtract(throwing, 'vid1', 1000)).toEqual([]);
+  });
+
+  it('响应非数组（协议异常）→ 空', async () => {
+    const webview: WebviewHandle = {
+      executeJavaScript: vi.fn(async () => ({ status: 200 })),
+      loadURL: vi.fn(),
+      getURL: vi.fn(),
+    };
+    expect(await tryExperimentalDirectExtract(webview, 'vid1', 1000)).toEqual([]);
+  });
+});
+
+describe('集成：manualResolveVideoArtifact 实验回退', () => {
+  const VID = 'vid_exp_001';
+
+  function createWebview(expResponses: string[] | null): WebviewHandle {
+    const mock: WebviewHandle = {
+      executeJavaScript: vi.fn(async (code: string): Promise<unknown> => {
+        await new Promise((r) => setTimeout(r, 5));
+        if (code.includes('function probe(path, body)')) {
+          return expResponses; // 实验通道：返回响应文本数组
+        }
+        if (code.includes('get_without_watermark')) {
+          return { status: 200, data: { code: 0, data: { without_watermark: false } } };
+        }
+        if (code.includes('get_play_info')) {
+          return { status: 200, data: { code: 0, data: {} } };
+        }
+        return null;
+      }),
+      loadURL: vi.fn(),
+      getURL: vi.fn(() => 'https://www.doubao.com/chat/'),
+    };
+    return mock;
+  }
+
+  it('实验关闭（默认）：官方 without_watermark=false → fail-closed unavailable', async () => {
+    const webview = createWebview(['{"code":0,"data":{"without_watermark":false}}', '{}']);
+    const result = await manualResolveVideoArtifact(webview, {
+      knownVid: VID,
+      timeoutMs: 3000,
+      // experimentalNoWatermark 未传 → 关闭
+    });
+    expect(result.status).toBe('unavailable');
+    expect(result.reason).toContain('without_watermark=false');
+  });
+
+  it('实验开启：官方拒绝 → 实验候选可用并标注 experimental', async () => {
+    const webview = createWebview([
+      JSON.stringify({ code: 0, data: { without_watermark: false, download_video: { [VID]: { download_url: 'https://vod.example.com/exp_a.mp4' } } } }),
+      '{}',
+    ]);
+    const result = await manualResolveVideoArtifact(webview, {
+      knownVid: VID,
+      timeoutMs: 3000,
+      experimentalNoWatermark: true,
+    });
+    expect(result.status).toBe('resolved');
+    expect(result.source).toBe('experimental');
+    expect(result.url).toContain('exp_a.mp4');
+  });
+
+  it('实验开启但无候选 → unavailable 且原因标注实验直取未获得源文件', async () => {
+    const webview = createWebview(null);
+    const result = await manualResolveVideoArtifact(webview, {
+      knownVid: VID,
+      timeoutMs: 3000,
+      experimentalNoWatermark: true,
+    });
+    expect(result.status).toBe('unavailable');
+    expect(result.reason).toContain('实验直取未获得可验证源文件');
+  });
+});


### PR DESCRIPTION
用户明确授权（非会员 + 知情接受绕过方案）的对抗性实验功能；治理偏离已记录。

## 实现
- 新 src/utils/experimentalNoWatermark.ts：实验开关（localStorage 默认关闭）+ 深度候选扫描（no_watermark_url/download_url/main_url）+ lr 参数改写 + 无条件读官方接口原始响应（不检查 without_watermark）
- esolveVideoArtifact 新增策略 6（实验）：官方授权失败后执行；候选 source='experimental'（isOriginal=false，最低信任优先级）
- selectBestCandidate：官方候选为空且开关开启时以实验候选兜底；失败原因标注「实验直取未获得可验证源文件」
- VideoArtifactSource 增加 'experimental'（SOURCE_PRIORITY=5 最低）
- BrowserPanel：工具栏「实验直取」Switch（默认关，开启需 Modal 二次风险确认）；仅手动提取生效，自动任务不受影响；结果来源标注「实验直取（未经官方授权）」

## 测试
- 新增 13 项（tests/unit/experimental-no-watermark.test.ts）：开关默认关闭/持久化/storage 异常防御、深度扫描、参数改写边界、直取候选提取与去重、集成（关闭保持 fail-closed；开启官方拒绝→实验候选；无候选→标注原因）
- 全量 730/730、ts-check 0、lint 0、build 0

## 风险声明（已告知用户）
- 可能违反豆包服务条款、触发账号风控；提取结果可能仍含水印（8-13 热修已验证参数伪装对当前平台可能无效）
- 默认关闭；开启仅影响手动提取；未打包发布