### PR TITLE
feat(projects): validate CSV project ownership and management

### DIFF
--- a/AGENT_EXECUTION_PLAN.md
+++ b/AGENT_EXECUTION_PLAN.md
@@ -308,10 +308,10 @@
 
 ### Agent 使用 CSV 导入的当前权威规则
 
-- 查询 CLI 与 MCP 仍为只读；`import-csv` 是唯一允许的 CLI 写入命令。
+- 查询 CLI 与 MCP 仍为只读；CLI 写入面仅允许 `import-csv` 和冻结范围、默认 dry-run 的受控项目迁移。
 - Agent 不得自动点击桌面文件选择器，也不得直接编辑 `tasks.json`。有桌面人工操作能力时，可使用 CSV 按钮或把单个 CSV 拖到任务调度区。
-- 无桌面操作时，先确认豆包工作室已退出，再执行：`pnpm run cli:import -- --csv <绝对路径.csv> --tasks-file <DoubaoStudioData\\tasks.json> [--accounts-file <DoubaoStudioData\\accounts.json>] [--project-id <id>]`。
-- `--tasks-file` 必须显式给出，禁止猜测旧工作树、仓库 `data/` 或历史版本的数据路径；账号文件默认取任务文件同目录。
+- 无桌面操作时，先确认豆包工作室已退出，再执行：`pnpm run cli:import -- --csv <绝对路径.csv> --tasks-file <DoubaoStudioData\\tasks.json> --projects-file <DoubaoStudioData\\projects.json> (--project-id <真实ID> | --project-name <新名称>) [--accounts-file <DoubaoStudioData\\accounts.json>]`。
+- `--tasks-file` 必须显式给出，禁止猜测旧工作树、仓库 `data/` 或历史版本的数据路径；账号与项目文件默认取任务文件同目录。项目名称不能充当项目 ID，同名创建必须产生不同 UUID。
 - 解析、账号匹配、依赖映射和写入必须经过 `TaskService.importCsv()`；任务文件在读取后发生变化时必须拒绝覆盖。
 - CSV 导入只创建任务，不代表已提交平台；实际执行仍经过账号可用性、额度、前台交互租约和不可重复提交门禁。
 - 免费视频额度按运行机器本地时区每日 00:00 重置预测值；平台明确返回耗尽时当日剩余立即归零并安全重排，提交状态不确定时禁止自动重发。

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ CSV 模板见 [`examples/tasks-template.csv`](examples/tasks-template.csv)。
 | `dependency_policy` | `all_done` 或 `all_finished` | `all_done` |
 
 > [!CAUTION]
-> `import-csv` CLI 会写入任务数据。必须先退出豆包工作室，再显式提供真实 `tasks.json`；不要让桌面程序与 CLI 同时写同一数据文件，也不要猜测历史工作树中的数据路径。
+> `import-csv` CLI 会写入项目和任务数据。必须先退出豆包工作室，再显式提供真实 `tasks.json` 与同目录 `projects.json`；不要让桌面程序与 CLI 同时写同一数据文件，也不要猜测历史工作树中的数据路径。`--project-id` 必须是真实 ID；如需新项目，使用 `--project-name` 创建，不要把项目名称填入 `--project-id`。
 
 ### 页面适配系统
 
@@ -249,9 +249,10 @@ CSV 模板见 [`examples/tasks-template.csv`](examples/tasks-template.csv)。
 
 ### CLI 与 MCP 边界（v2.3）
 
-- CLI 的 `list / task / outputs / diagnostics` 保持只读；`import-csv` 是唯一显式写入命令，并复用 `TaskService.importCsv()`。
-- Agent 使用写入命令时必须同时提供 `--csv` 和真实桌面数据目录中的 `--tasks-file`；可选 `--accounts-file`（默认与 tasks 文件同目录）和 `--project-id`。文件在导入期间发生漂移会 fail-closed，桌面程序运行时不要直接调用文件写入 CLI。
-- 示例：`pnpm run cli:import -- --csv "D:\\batch.csv" --tasks-file "C:\\...\\DoubaoStudioData\\tasks.json" --accounts-file "C:\\...\\DoubaoStudioData\\accounts.json"`。
+- CLI 的 `list / task / outputs / diagnostics` 保持只读；写入面仅有 `import-csv` 和冻结范围的一次性项目迁移。
+- `import-csv` 必须提供 `--csv`、真实 `--tasks-file` 与可推导/显式 `--projects-file`。使用 `--project-id <真实ID>` 导入现有项目，或使用互斥的 `--project-name <名称>` 创建新 UUID 后导入；同名项目不会自动合并。未知 ID 返回 `PROJECT_NOT_FOUND`，任务台账不变。
+- 示例：`pnpm run cli:import -- --csv "D:\\batch.csv" --tasks-file "C:\\...\\DoubaoStudioData\\tasks.json" --projects-file "C:\\...\\DoubaoStudioData\\projects.json" --project-id "<项目ID>"`。
+- CLI 只输出导入数、跳过数、项目 ID、批次 ID 和错误摘要，不回显提示词或素材绝对路径。项目和任务文件在读取后漂移均 fail-closed，桌面程序运行时禁止调用写入 CLI。
 - MCP 服务端（`pnpm run mcp:server`）：JSON-RPC 2.0 over stdio，暴露 `doubao.list_tasks` / `doubao.get_task` 两个只读工具；由外部 MCP 客户端（如 Claude Desktop、Alice-agent 生态）接入。
 - MCP 客户端（`pnpm run mcp:client`）：stdio 客户端核心（initialize / tools/list / tools/call / ping），支持 `tools / call / audit` 三个只读命令：
   - 连接配置来自用户显式提供的 JSON 文件（`--connections-file`），**无内置连接、不自动连接任何服务**。
@@ -314,7 +315,7 @@ pnpm run dev
 
 ```powershell
 pnpm run build:main
-pnpm run cli:import -- --csv "D:\batch.csv" --tasks-file "C:\Users\<你>\AppData\Roaming\<应用数据目录>\DoubaoStudioData\tasks.json" --accounts-file "C:\Users\<你>\AppData\Roaming\<应用数据目录>\DoubaoStudioData\accounts.json"
+pnpm run cli:import -- --csv "D:\batch.csv" --tasks-file "C:\Users\<你>\AppData\Roaming\<应用数据目录>\DoubaoStudioData\tasks.json" --projects-file "C:\Users\<你>\AppData\Roaming\<应用数据目录>\DoubaoStudioData\projects.json" --project-id "<项目ID>" --accounts-file "C:\Users\<你>\AppData\Roaming\<应用数据目录>\DoubaoStudioData\accounts.json"
 ```
 
 CLI 只创建本地任务，不会自动提交到豆包；导入后的任务仍需经过账号健康、额度、依赖和提交门禁。
@@ -333,7 +334,8 @@ CLI 只创建本地任务，不会自动提交到豆包；导入后的任务仍�
 | `pnpm run dist:win` | 生成 Windows 安装包 |
 | `pnpm run pack` | 生成未安装的打包目录 |
 | `pnpm run cli:list` | 只读 CLI：列出任务 |
-| `pnpm run cli:import -- --csv <csv> --tasks-file <tasks.json>` | 显式写入 CLI：通过 TaskService 导入 CSV；桌面程序运行时禁用 |
+| `pnpm run cli:import -- --csv <csv> --tasks-file <tasks.json> --project-id <id>` | 显式写入 CLI：校验项目后通过 TaskService 导入 CSV；桌面程序运行时禁用 |
+| `pnpm run cli:migrate-project -- ...` | 冻结范围项目迁移；默认 dry-run，只有显式确认与全部不变量通过才写入 |
 | `pnpm run mcp:server` | 启动 MCP stdio 服务端（只读工具） |
 | `pnpm run mcp:client` | 启动 MCP 客户端 CLI（`tools` / `call` / `audit`） |
 

--- a/docs/handoffs/2026-08-27-doubao-project-csv-visibility-and-management-01.md
+++ b/docs/handoffs/2026-08-27-doubao-project-csv-visibility-and-management-01.md
@@ -1,0 +1,120 @@
+# DOUBAO-PROJECT-CSV-VISIBILITY-AND-MANAGEMENT-01 实施与验收报告
+
+## 1. 治理规则与冻结验收包
+
+已按顺序读取总架构师治理规则、仓库 `AGENTS.md`、问题报告、最新相关 handoff 与项目/任务/CLI/Contracts/Preload/Store 源码。仓库中不存在 `docs/memory/INDEX.md`、`CURRENT.md`、`DEPENDENCIES.md`、`QUEUE.md`，按实际缺失记录，未虚构读取。
+
+本轮冻结验收包：
+
+- P0-1：CLI 项目完整性、`PROJECT_NOT_FOUND` fail-closed、新 UUID 项目创建、脱敏输出。
+- P0-2：冻结来源/目标/12 项 queued video 的默认 dry-run 受控迁移，原文漂移拒绝、原子替换与迁移后回读。
+- P0-3：项目任务数、编辑、归档、安全删除和当前项目任务统计界面。
+
+非目标保持不变：不提交平台任务、不上传素材、不消耗额度、不改 Cookie/Token/Session/视频产物，不重构视频生成、账号调度或音轨逻辑。
+
+## 2. Git 基线与状态
+
+- 工作树：`D:\豆包工作室\doubao-automation-closeout-01`
+- 分支：`codex/doubao-project-csv-visibility-management-01`
+- 基线/当前 HEAD：`1b04cbc36b5f973300ab4d6b86c731d4700485e6`
+- `origin/main`（开工时）：`1b04cbc36b5f973300ab4d6b86c731d4700485e6`
+- 开工状态：clean
+- 收口状态：15 个候选文件，全部未暂存、未提交
+
+## 3. 实现结果
+
+### P0-1 CLI 项目完整性
+
+- `import-csv` 在创建任务存储与读取/写入 `tasks.json` 前读取 `projects.json` 并校验真实项目 ID。
+- 未知 ID 固定返回 `PROJECT_NOT_FOUND`，任务文件保持逐字节不变。
+- `--project-id` 与 `--project-name` 互斥；`--project-name` 每次创建新的 UUID，同名项目不复用、不把名称当 ID。
+- 项目文件以原文作为并发基线，使用同目录临时文件 + rename 原子替换；漂移返回 `PROJECTS_FILE_CHANGED`。
+- 成功输出投影为 `imported/skipped/projectId/batchId/errors`，不返回 tasks、提示词或素材绝对路径。
+
+### P0-2 一次性孤儿任务修复
+
+- 新增 `migrate-project-tasks` / `pnpm run cli:migrate-project`。
+- 范围硬冻结为：
+  - 来源 `MY-CATSCRATCHER-VIDEO-20260824-01`
+  - 目标 `30c20259-58bd-4f01-8a70-f6c8d0a0732d`
+  - 恰好 12 项 `queued + video`
+- 默认仅 dry-run；仅 `--confirm 12` 执行写入。
+- 写入前校验目标项目存在、目标当前为空、默认项目恰好 4 项 done；任务原文发生漂移即 `TASKS_FILE_CHANGED`。
+- 写入使用同目录临时文件原子替换；写入后重新读取并校验来源 0、目标 12 queued/video、默认项目 4 项 done 完整对象指纹不变。
+
+### P0-3 项目管理界面
+
+- 项目下拉旁增加“管理项目”入口。
+- 管理界面显示完整项目 ID、总任务、排队、运行、完成数量；支持编辑名称/说明、归档/恢复和删除。
+- 默认项目禁止归档和删除；含任务项目由后端返回真实 `taskCount` 并拒绝删除；空项目经 `Popconfirm` 二次确认后删除并切回默认项目。
+- 项目 IPC 对 `writeJSON=false` 统一 fail-closed，不再返回虚假成功；更新只接受冻结字段，空名称拒绝。
+- 任务调度标题显示当前项目名称/ID，排队、运行、完成统计即使为 0 也始终显示。
+
+## 4. 实际候选文件
+
+Tracked 修改（10）：
+
+1. `AGENT_EXECUTION_PLAN.md`
+2. `README.md`
+3. `main/cli/doubaoCliEntry.ts`
+4. `main/ipc/projects.ts`
+5. `package.json`
+6. `packages/contracts/src/dto/projects.ts`
+7. `src/components/ProjectSwitcher.tsx`
+8. `src/components/TaskConsole.tsx`
+9. `src/store/useProjectStore.ts`
+10. `tests/unit/csvProductionExperience.test.ts`
+
+Untracked 新增（5）：
+
+1. `main/cli/projectTaskMigration.ts`
+2. `main/utils/projectManagement.ts`
+3. `src/components/ProjectManagementModal.tsx`
+4. `tests/unit/projectCsvVisibility.test.ts`
+5. `docs/handoffs/2026-08-27-doubao-project-csv-visibility-and-management-01.md`
+
+真正 tracked 删除：0。
+
+## 5. 测试与门禁
+
+- 专项：`tests/unit/projectCsvVisibility.test.ts` + `tests/unit/csvProductionExperience.test.ts`，2 files / 38 pass / 0 fail。
+- 类型检查：contracts/main/renderer/tests 全部通过，0 error。
+- ESLint：0 error / 142 warning，低于 149 上限；本轮新增文件无 lint error。
+- 工程与 contracts 边界：全部通过。
+- 全量 Vitest：38 files / 886 pass / 0 fail。
+- Renderer 构建：PASS。
+- Main 构建：PASS。
+- `git diff --check`：PASS。
+
+## 6. 一次性本地台账迁移证据
+
+- 数据目录：`C:\Users\Administrator\AppData\Roaming\doubao-studio-desktop\DoubaoStudioData`
+- 执行前先运行默认 dry-run：affected=12、source after=0、target after=12、default done=4，全部冻结不变量匹配。
+- 检测到桌面应用运行后，先关闭该开发实例并确认相关 Electron 进程退出，避免双写。
+- 明确执行 `--confirm 12` 后回读：
+  - 来源项目：0
+  - 目标项目：12 项 queued/video
+  - 默认项目：4 项 done，完整对象指纹保持不变
+- `tasks.json` SHA-256：
+  - before：`338027460E7CB721D56D50D6D50CC73B7ACA01872C27A6CC3C5A82CA709BB01E`
+  - after：`32D910D930EBACB8306834EEA6A7409FAFFB43F91B64E3CD5F8427BF14344AA9`
+- `projects.json`：前后 SHA-256 相同。
+
+这是一项本地任务台账归属修复，不是平台任务执行；未提交、上传或生成任何真实视频，额度消耗为 0。
+
+## 7. 五态与停止声明
+
+- 代码已实现：是。
+- 自动化测试：通过。
+- 人工界面验收：未完成。Windows 桌面控制运行时返回 `unavailable`，未使用不受控坐标或替代点击方式虚报结果。
+- 真实任务执行：未执行。
+- 一次性本地台账迁移：已执行并回读通过。
+- Git 提交/推送：未执行。
+- 部署/发布：未执行。
+- 豆包工作室当前状态：为避免迁移双写已关闭，未自动重启。
+
+## 8. 单一裁决
+
+**PASS（代码、自动化门禁与一次性迁移） / 人工界面验收待桌面控制恢复后补做。**
+
+禁止将本裁决解释为已提交、已推送、已部署、已发布或已完成真实平台任务。

--- a/main/cli/doubaoCliEntry.ts
+++ b/main/cli/doubaoCliEntry.ts
@@ -1,8 +1,8 @@
 /**
- * 查询命令保持只读；import-csv 是唯一显式写入命令（零 Electron）。
+ * 查询命令保持只读；import-csv 与受控项目迁移是显式写入命令（零 Electron）。
  *
  * 运行：node dist/main/cli/doubaoCliEntry.js <command> [options]
- *   commands: list | task <id> | outputs | diagnostics | import-csv
+ *   commands: list | task <id> | outputs | diagnostics | import-csv | migrate-project-tasks
  *   options : --tasks-file <json>（默认 data/tasks.json）--status --keyword --limit
  */
 import { readFileSync, writeFileSync, renameSync, unlinkSync, existsSync, statSync } from 'node:fs';
@@ -10,6 +10,7 @@ import { dirname, extname, join, resolve } from 'node:path';
 import { TaskService } from '../core/TaskService';
 import { buildCliActions } from './doubaoCli';
 import type { Task } from '@doubao-studio/contracts';
+import { createProjectInFile, migrateProjectTasks, requireProject } from './projectTaskMigration';
 
 /** JSON 文件任务存储（只读面；replace 恒 false —— CLI 无写路径）。 */
 export function createFileTaskStore(filePath: string) {
@@ -94,7 +95,8 @@ export function runCli(args: string[], write: (s: string) => void = console.log)
     task: new Set(['tasks-file']),
     outputs: new Set(['tasks-file']),
     diagnostics: new Set(['tasks-file']),
-    'import-csv': new Set(['tasks-file', 'csv', 'accounts-file', 'project-id']),
+    'import-csv': new Set(['tasks-file', 'projects-file', 'csv', 'accounts-file', 'project-id', 'project-name']),
+    'migrate-project-tasks': new Set(['tasks-file', 'projects-file', 'source-project-id', 'target-project-id', 'confirm']),
     help: new Set(),
   };
   if (invalidArguments || !allowedByCommand[command] || Object.keys(options).some((key) => !allowedByCommand[command].has(key))) {
@@ -106,32 +108,91 @@ export function runCli(args: string[], write: (s: string) => void = console.log)
   if (command === 'import-csv') {
     const csvPath = options.csv ? resolve(options.csv) : '';
     const explicitTasksFile = options['tasks-file'] ? resolve(options['tasks-file']) : '';
-    if (!csvPath || !explicitTasksFile || extname(csvPath).toLowerCase() !== '.csv') {
+    if (!csvPath || !explicitTasksFile || extname(csvPath).toLowerCase() !== '.csv' ||
+        (options['project-id'] !== undefined && options['project-name'] !== undefined)) {
       const output = JSON.stringify({ ok: false, error: 'INVALID_ARGUMENTS' });
       write(output);
       return { exitCode: 1, output };
     }
+    let projectId = options['project-id'] || 'default-project';
+    let createdProjectId: string | undefined;
     try {
       const csvStat = statSync(csvPath);
       if (!csvStat.isFile() || csvStat.size <= 0 || csvStat.size > 10 * 1024 * 1024) throw new Error('CSV_INVALID');
+      const projectsFile = resolve(options['projects-file'] || join(dirname(explicitTasksFile), 'projects.json'));
+      if (options['project-name'] !== undefined) {
+        const project = createProjectInFile(projectsFile, options['project-name']);
+        projectId = project.id;
+        createdProjectId = project.id;
+      } else {
+        requireProject(projectsFile, projectId);
+      }
       const accountsFile = resolve(options['accounts-file'] || join(dirname(explicitTasksFile), 'accounts.json'));
       const accountsRaw = existsSync(accountsFile) ? JSON.parse(readFileSync(accountsFile, 'utf8')) as unknown : [];
       if (!Array.isArray(accountsRaw)) throw new Error('ACCOUNTS_FILE_INVALID');
       const service = new TaskService({
         store: createWritableFileTaskStore(explicitTasksFile),
-        defaultProjectId: () => options['project-id'] || 'default-project',
+        defaultProjectId: () => projectId,
       });
       const imported = service.importCsv({
         text: readFileSync(csvPath, 'utf8'),
         accounts: accountsRaw as Array<{ id: string; name: string; platform?: 'doubao' | 'dola' }>,
-        projectId: options['project-id'],
+        projectId,
       });
-      const result = imported.success ? { ok: true, data: imported.data } : { ok: false, error: imported.error };
+      const result = imported.success ? {
+        ok: true,
+        data: {
+          imported: imported.data?.imported ?? 0,
+          skipped: imported.data?.skipped ?? 0,
+          projectId,
+          batchId: imported.data?.batchId ?? '',
+          errors: imported.data?.errors ?? [],
+        },
+      } : { ok: false, error: imported.error, ...(createdProjectId ? { projectId: createdProjectId } : {}) };
       const output = JSON.stringify(result);
       write(output);
       return { exitCode: result.ok ? 0 : 1, output };
-    } catch {
-      const output = JSON.stringify({ ok: false, error: 'CSV_IMPORT_FAILED' });
+    } catch (caught) {
+      const code = caught instanceof Error && [
+        'PROJECT_NOT_FOUND', 'PROJECTS_FILE_NOT_FOUND', 'PROJECTS_FILE_INVALID', 'PROJECTS_FILE_CHANGED',
+        'INVALID_PROJECT_NAME', 'TASKS_FILE_NOT_FOUND', 'TASKS_FILE_INVALID', 'TASKS_FILE_CHANGED',
+      ].includes(caught.message) ? caught.message : 'CSV_IMPORT_FAILED';
+      const output = JSON.stringify({ ok: false, error: code, ...(createdProjectId ? { projectId: createdProjectId } : {}) });
+      write(output);
+      return { exitCode: 1, output };
+    }
+  }
+
+  if (command === 'migrate-project-tasks') {
+    const explicitTasksFile = options['tasks-file'] ? resolve(options['tasks-file']) : '';
+    const projectsFile = options['projects-file'] ? resolve(options['projects-file']) : '';
+    const sourceProjectId = options['source-project-id'] || '';
+    const targetProjectId = options['target-project-id'] || '';
+    if (!explicitTasksFile || !projectsFile || !sourceProjectId || !targetProjectId ||
+        (options.confirm !== undefined && options.confirm !== '12')) {
+      const output = JSON.stringify({ ok: false, error: 'INVALID_ARGUMENTS' });
+      write(output);
+      return { exitCode: 1, output };
+    }
+    try {
+      const data = migrateProjectTasks({
+        tasksFile: explicitTasksFile,
+        projectsFile,
+        sourceProjectId,
+        targetProjectId,
+        confirm: options.confirm === undefined ? undefined : Number(options.confirm),
+      });
+      const output = JSON.stringify({ ok: true, data });
+      write(output);
+      return { exitCode: 0, output };
+    } catch (caught) {
+      const allowedErrors = new Set([
+        'MIGRATION_SCOPE_NOT_ALLOWED', 'PROJECT_NOT_FOUND', 'PROJECTS_FILE_NOT_FOUND', 'PROJECTS_FILE_INVALID',
+        'TASKS_FILE_NOT_FOUND', 'TASKS_FILE_INVALID', 'TASKS_FILE_CHANGED', 'MIGRATION_SOURCE_MISMATCH',
+        'MIGRATION_TARGET_NOT_EMPTY', 'MIGRATION_DEFAULT_INVARIANT_MISMATCH', 'MIGRATION_VERIFY_FAILED',
+      ]);
+      const code = caught instanceof Error && allowedErrors.has(caught.message) ? caught.message : 'MIGRATION_FAILED';
+      const output = JSON.stringify({ ok: false, error: code });
       write(output);
       return { exitCode: 1, output };
     }
@@ -159,7 +220,7 @@ export function runCli(args: string[], write: (s: string) => void = console.log)
       result = cli.diagnostics();
       break;
     case 'help':
-      write('doubao-cli <list|task <id>|outputs|diagnostics|import-csv> [--tasks-file <json>] [--csv <csv>] [--accounts-file <json>] [--project-id <id>]');
+      write('doubao-cli <list|task <id>|outputs|diagnostics|import-csv|migrate-project-tasks> [options]');
       return { exitCode: 0, output: 'help' };
     default:
       result = { ok: false, error: 'UNKNOWN_COMMAND' };

--- a/main/cli/projectTaskMigration.ts
+++ b/main/cli/projectTaskMigration.ts
@@ -1,0 +1,120 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
+import type { Project, Task } from '@doubao-studio/contracts';
+import { createProjectRecord, DEFAULT_PROJECT_ID } from '../utils/projectManagement';
+
+export const FROZEN_MIGRATION = {
+  sourceProjectId: 'MY-CATSCRATCHER-VIDEO-20260824-01',
+  targetProjectId: '30c20259-58bd-4f01-8a70-f6c8d0a0732d',
+  expectedCount: 12,
+} as const;
+
+function error(code: string): never {
+  throw new Error(code);
+}
+
+function parseArrayFile<T>(filePath: string, missingCode: string, invalidCode: string): { raw: string; items: T[] } {
+  if (!existsSync(filePath)) error(missingCode);
+  const raw = readFileSync(filePath, 'utf8');
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) error(invalidCode);
+    return { raw, items: parsed as T[] };
+  } catch (caught) {
+    if (caught instanceof Error && caught.message === invalidCode) throw caught;
+    error(invalidCode);
+  }
+}
+
+function atomicReplace(filePath: string, baseline: string, data: unknown, suffix: string): void {
+  if (readFileSync(filePath, 'utf8') !== baseline) error(`${suffix}_FILE_CHANGED`);
+  const temp = `${filePath}.${process.pid}.${suffix.toLowerCase()}.tmp`;
+  try {
+    writeFileSync(temp, JSON.stringify(data, null, 2), 'utf8');
+    renameSync(temp, filePath);
+  } finally {
+    if (existsSync(temp)) unlinkSync(temp);
+  }
+}
+
+export function readProjectsFile(filePath: string): { raw: string; projects: Project[] } {
+  const result = parseArrayFile<Project>(filePath, 'PROJECTS_FILE_NOT_FOUND', 'PROJECTS_FILE_INVALID');
+  return { raw: result.raw, projects: result.items };
+}
+
+export function requireProject(filePath: string, projectId: string): Project {
+  const { projects } = readProjectsFile(filePath);
+  const project = projects.find((item) => item.id === projectId);
+  if (!project) error('PROJECT_NOT_FOUND');
+  return project;
+}
+
+export function createProjectInFile(filePath: string, name: string): Project {
+  const { raw, projects } = readProjectsFile(filePath);
+  const project = createProjectRecord(randomUUID(), name);
+  if (!project) error('INVALID_PROJECT_NAME');
+  atomicReplace(filePath, raw, [...projects, project], 'PROJECTS');
+  return project;
+}
+
+function stableFingerprint(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+export interface MigrationSummary {
+  dryRun: boolean;
+  affected: number;
+  sourceProjectId: string;
+  targetProjectId: string;
+  sourceQueuedVideoAfter: number;
+  targetQueuedVideoAfter: number;
+  defaultDoneAfter: number;
+}
+
+export function migrateProjectTasks(params: {
+  tasksFile: string;
+  projectsFile: string;
+  sourceProjectId: string;
+  targetProjectId: string;
+  confirm?: number;
+  beforeWrite?: () => void;
+}): MigrationSummary {
+  const frozen = FROZEN_MIGRATION;
+  if (params.sourceProjectId !== frozen.sourceProjectId || params.targetProjectId !== frozen.targetProjectId) {
+    error('MIGRATION_SCOPE_NOT_ALLOWED');
+  }
+  requireProject(params.projectsFile, params.targetProjectId);
+  const { raw, items: tasks } = parseArrayFile<Task>(params.tasksFile, 'TASKS_FILE_NOT_FOUND', 'TASKS_FILE_INVALID');
+  const source = tasks.filter((task) => task.projectId === params.sourceProjectId);
+  const target = tasks.filter((task) => task.projectId === params.targetProjectId);
+  const defaultDone = tasks.filter((task) => (task.projectId || DEFAULT_PROJECT_ID) === DEFAULT_PROJECT_ID && task.status === 'done');
+  if (source.length !== frozen.expectedCount || source.some((task) => task.status !== 'queued' || task.mode !== 'video')) {
+    error('MIGRATION_SOURCE_MISMATCH');
+  }
+  if (target.length !== 0) error('MIGRATION_TARGET_NOT_EMPTY');
+  if (defaultDone.length !== 4) error('MIGRATION_DEFAULT_INVARIANT_MISMATCH');
+  const defaultFingerprint = stableFingerprint(defaultDone);
+  const summary: MigrationSummary = {
+    dryRun: params.confirm !== frozen.expectedCount,
+    affected: source.length,
+    sourceProjectId: params.sourceProjectId,
+    targetProjectId: params.targetProjectId,
+    sourceQueuedVideoAfter: 0,
+    targetQueuedVideoAfter: frozen.expectedCount,
+    defaultDoneAfter: defaultDone.length,
+  };
+  if (summary.dryRun) return summary;
+
+  const sourceIds = new Set(source.map((task) => task.id));
+  const next = tasks.map((task) => sourceIds.has(task.id) ? { ...task, projectId: params.targetProjectId } : task);
+  params.beforeWrite?.();
+  atomicReplace(params.tasksFile, raw, next, 'TASKS');
+  const reread = parseArrayFile<Task>(params.tasksFile, 'TASKS_FILE_NOT_FOUND', 'TASKS_FILE_INVALID').items;
+  const sourceAfter = reread.filter((task) => task.projectId === params.sourceProjectId);
+  const targetAfter = reread.filter((task) => task.projectId === params.targetProjectId && task.status === 'queued' && task.mode === 'video');
+  const defaultDoneAfter = reread.filter((task) => (task.projectId || DEFAULT_PROJECT_ID) === DEFAULT_PROJECT_ID && task.status === 'done');
+  if (sourceAfter.length !== 0 || targetAfter.length !== frozen.expectedCount || stableFingerprint(defaultDoneAfter) !== defaultFingerprint) {
+    error('MIGRATION_VERIFY_FAILED');
+  }
+  return { ...summary, dryRun: false, sourceQueuedVideoAfter: sourceAfter.length, targetQueuedVideoAfter: targetAfter.length, defaultDoneAfter: defaultDoneAfter.length };
+}

--- a/main/ipc/projects.ts
+++ b/main/ipc/projects.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { readJSON, writeJSON } from '../utils/store';
 import type { Project, ProjectAddParams, ProjectUpdateParams, ProjectIdParams } from '@doubao-studio/contracts';
 import { replaceIpcHandlers } from './lifecycle';
+import { createProjectRecord, DEFAULT_PROJECT_ID, deleteProjectRecord, updateProjectRecord } from '../utils/projectManagement';
 
 // 领域模型接口和 IPC DTO 已迁移至 @doubao-studio/contracts。
 // 此处通过 import type 引用，不产生运行时依赖。
@@ -10,14 +11,12 @@ import { replaceIpcHandlers } from './lifecycle';
 export type { Project };
 
 const STORE_FILE = 'projects.json';
-const DEFAULT_PROJECT_ID = 'default-project';
-
 export function loadProjects(): Project[] {
   const projects = readJSON<Project[]>(STORE_FILE, []);
   if (!projects.some((project) => project.id === DEFAULT_PROJECT_ID)) {
     const now = new Date().toISOString();
     projects.unshift({ id: DEFAULT_PROJECT_ID, name: '默认项目', description: '由旧版本任务自动迁移', color: '#6d5dfc', archived: false, createdAt: now, updatedAt: now });
-    writeJSON(STORE_FILE, projects);
+    if (!writeJSON(STORE_FILE, projects)) throw new Error('PROJECTS_WRITE_FAILED');
   }
   return projects;
 }
@@ -37,29 +36,26 @@ export function registerProjectIPC(): () => void {
     if (!params.name?.trim()) return { success: false, error: '项目名称不能为空' };
     const projects = loadProjects();
     const now = new Date().toISOString();
-    const project: Project = { id: uuidv4(), name: params.name.trim(), description: params.description?.trim() || '', color: params.color || '#6d5dfc', archived: false, createdAt: now, updatedAt: now };
+    const project = createProjectRecord(uuidv4(), params.name, params.description, params.color, now);
+    if (!project) return { success: false, error: '项目名称不能为空' };
     projects.push(project);
-    writeJSON(STORE_FILE, projects);
+    if (!writeJSON(STORE_FILE, projects)) return { success: false, error: '项目写入失败' };
     return { success: true, project };
   });
   ipcMain.handle('projects:update', async (_event, params: ProjectUpdateParams) => {
     const projects = loadProjects();
-    const project = projects.find((item) => item.id === params.id);
-    if (!project) return { success: false, error: '项目不存在' };
-    Object.assign(project, params.updates, { updatedAt: new Date().toISOString() });
-    writeJSON(STORE_FILE, projects);
-    return { success: true, project };
+    const updated = updateProjectRecord(projects, params.id, params.updates);
+    if (!updated.success) return updated;
+    if (!writeJSON(STORE_FILE, updated.projects)) return { success: false, error: '项目写入失败' };
+    return { success: true, project: updated.project };
   });
   ipcMain.handle('projects:delete', async (_event, params: ProjectIdParams) => {
-    if (params.id === DEFAULT_PROJECT_ID) return { success: false, error: '默认项目不能删除' };
     const projects = loadProjects();
-    const next = projects.filter((project) => project.id !== params.id);
-    if (next.length === projects.length) return { success: false, error: '项目不存在' };
     const tasks = readJSON<Array<{ projectId?: string }>>('tasks.json', []);
-    const taskCount = tasks.filter((task) => task.projectId === params.id).length;
-    if (taskCount > 0) return { success: false, error: `项目仍包含 ${taskCount} 个任务，请先迁移或删除任务` };
-    writeJSON(STORE_FILE, next);
-    return { success: true };
+    const deleted = deleteProjectRecord(projects, tasks, params.id);
+    if (!deleted.success) return deleted;
+    if (!writeJSON(STORE_FILE, deleted.projects)) return { success: false, error: '项目写入失败', taskCount: 0 };
+    return { success: true, taskCount: 0 };
   });
   console.log('[IPC] 项目管理模块已注册');
   return dispose;

--- a/main/utils/projectManagement.ts
+++ b/main/utils/projectManagement.ts
@@ -1,0 +1,64 @@
+import type { Project } from '@doubao-studio/contracts';
+
+export const DEFAULT_PROJECT_ID = 'default-project';
+
+export interface ProjectTaskCount {
+  projectId?: string;
+}
+
+export function createProjectRecord(
+  id: string,
+  name: string,
+  description = '',
+  color = '#6d5dfc',
+  now = new Date().toISOString(),
+): Project | null {
+  const normalizedName = name.trim();
+  if (!normalizedName) return null;
+  return {
+    id,
+    name: normalizedName,
+    description: description.trim(),
+    color,
+    archived: false,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function updateProjectRecord(
+  projects: readonly Project[],
+  id: string,
+  updates: Partial<Pick<Project, 'name' | 'description' | 'color' | 'archived'>>,
+  now = new Date().toISOString(),
+): { success: true; projects: Project[]; project: Project } | { success: false; error: string } {
+  const current = projects.find((project) => project.id === id);
+  if (!current) return { success: false, error: '项目不存在' };
+  if (updates.name !== undefined && !updates.name.trim()) return { success: false, error: '项目名称不能为空' };
+  if (id === DEFAULT_PROJECT_ID && updates.archived === true) return { success: false, error: '默认项目不能归档' };
+  const project: Project = {
+    ...current,
+    ...(updates.name === undefined ? {} : { name: updates.name.trim() }),
+    ...(updates.description === undefined ? {} : { description: updates.description.trim() }),
+    ...(updates.color === undefined ? {} : { color: updates.color }),
+    ...(updates.archived === undefined ? {} : { archived: updates.archived }),
+    updatedAt: now,
+  };
+  return {
+    success: true,
+    projects: projects.map((item) => item.id === id ? project : item),
+    project,
+  };
+}
+
+export function deleteProjectRecord(
+  projects: readonly Project[],
+  tasks: readonly ProjectTaskCount[],
+  id: string,
+): { success: true; projects: Project[]; taskCount: 0 } | { success: false; error: string; taskCount?: number } {
+  if (id === DEFAULT_PROJECT_ID) return { success: false, error: '默认项目不能删除' };
+  if (!projects.some((project) => project.id === id)) return { success: false, error: '项目不存在' };
+  const taskCount = tasks.filter((task) => (task.projectId || DEFAULT_PROJECT_ID) === id).length;
+  if (taskCount > 0) return { success: false, error: `项目仍包含 ${taskCount} 个任务，请先迁移任务`, taskCount };
+  return { success: true, projects: projects.filter((project) => project.id !== id), taskCount: 0 };
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "validate": "pnpm run ts-check && pnpm run lint && pnpm run check:project && pnpm run test && pnpm run build",
     "cli:list": "node dist/main/cli/doubaoCliEntry.js list",
     "cli:import": "node dist/main/cli/doubaoCliEntry.js import-csv",
+    "cli:migrate-project": "node dist/main/cli/doubaoCliEntry.js migrate-project-tasks",
     "mcp:server": "node dist/main/mcp/doubaoMcpServer.js",
     "mcp:client": "node dist/main/mcp/mcpClientCli.js"
   },

--- a/packages/contracts/src/dto/projects.ts
+++ b/packages/contracts/src/dto/projects.ts
@@ -13,6 +13,7 @@ import type { Project } from '../domain';
 export interface ProjectOperationResult {
   success: boolean;
   error?: string;
+  taskCount?: number;
 }
 
 /** 项目操作结果（包含项目数据） */

--- a/src/components/ProjectManagementModal.tsx
+++ b/src/components/ProjectManagementModal.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Button, Descriptions, Input, Modal, Popconfirm, Select, Space, Tag, message } from 'antd';
+import { useProjectStore } from '../store/useProjectStore';
+import { useTaskStore } from '../store/useTaskStore';
+
+const DEFAULT_PROJECT_ID = 'default-project';
+const RUNNING_STATUSES = new Set(['executing', 'generating', 'waiting_verification']);
+
+export const ProjectManagementModal: React.FC<{ open: boolean; onClose: () => void }> = ({ open, onClose }) => {
+  const { projects, activeProjectId, selectProject, updateProject, deleteProject } = useProjectStore();
+  const tasks = useTaskStore((state) => state.tasks);
+  const [selectedId, setSelectedId] = useState(activeProjectId);
+  const selected = projects.find((project) => project.id === selectedId) || projects[0];
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+
+  useEffect(() => { if (open) setSelectedId(activeProjectId); }, [activeProjectId, open]);
+  useEffect(() => {
+    setName(selected?.name || '');
+    setDescription(selected?.description || '');
+  }, [selected]);
+
+  const counts = useMemo(() => {
+    const projectTasks = tasks.filter((task) => (task.projectId || DEFAULT_PROJECT_ID) === selected?.id);
+    return {
+      total: projectTasks.length,
+      queued: projectTasks.filter((task) => task.status === 'queued').length,
+      running: projectTasks.filter((task) => RUNNING_STATUSES.has(task.status)).length,
+      done: projectTasks.filter((task) => task.status === 'done').length,
+    };
+  }, [selected?.id, tasks]);
+
+  const save = async () => {
+    if (!selected) return;
+    const result = await updateProject(selected.id, { name, description });
+    if (result.success) message.success('项目资料已更新');
+    else message.error(result.error || '项目更新失败');
+  };
+
+  const toggleArchived = async () => {
+    if (!selected) return;
+    const result = await updateProject(selected.id, { archived: !selected.archived });
+    if (result.success) message.success(selected.archived ? '项目已恢复' : '项目已归档');
+    else message.error(result.error || '项目归档失败');
+  };
+
+  const remove = async () => {
+    if (!selected) return;
+    const result = await deleteProject(selected.id);
+    if (!result.success) {
+      message.error(result.taskCount ? `项目含 ${result.taskCount} 项任务，不能删除` : (result.error || '项目删除失败'));
+      return;
+    }
+    setSelectedId(DEFAULT_PROJECT_ID);
+    selectProject(DEFAULT_PROJECT_ID);
+    message.success('空项目已删除，已切回默认项目');
+  };
+
+  return (
+    <Modal title="管理项目" open={open} onCancel={onClose} footer={null} width={620} destroyOnClose>
+      <Select
+        value={selected?.id}
+        onChange={setSelectedId}
+        style={{ width: '100%', marginBottom: 16 }}
+        options={projects.map((project) => ({ value: project.id, label: `${project.name}${project.archived ? '（已归档）' : ''}` }))}
+      />
+      {selected && (
+        <Space direction="vertical" size={14} style={{ width: '100%' }}>
+          <Descriptions size="small" column={1} bordered>
+            <Descriptions.Item label="项目 ID"><span style={{ userSelect: 'text' }}>{selected.id}</span></Descriptions.Item>
+            <Descriptions.Item label="任务数量">
+              <Space wrap>
+                <Tag>全部 {counts.total}</Tag><Tag color="gold">排队 {counts.queued}</Tag>
+                <Tag color="blue">运行 {counts.running}</Tag><Tag color="green">完成 {counts.done}</Tag>
+              </Space>
+            </Descriptions.Item>
+          </Descriptions>
+          <Input value={name} onChange={(event) => setName(event.target.value)} placeholder="项目名称" />
+          <Input.TextArea value={description} onChange={(event) => setDescription(event.target.value)} placeholder="项目说明" rows={3} />
+          <Space wrap>
+            <Button type="primary" onClick={() => void save()}>保存名称与说明</Button>
+            <Button disabled={selected.id === DEFAULT_PROJECT_ID} onClick={() => void toggleArchived()}>
+              {selected.archived ? '恢复项目' : '归档项目'}
+            </Button>
+            <Popconfirm
+              title="确认删除这个空项目？"
+              description="只删除项目记录，不删除任务、素材或视频产物。"
+              okText="确认删除"
+              cancelText="取消"
+              disabled={selected.id === DEFAULT_PROJECT_ID || counts.total > 0}
+              onConfirm={() => void remove()}
+            >
+              <Button danger disabled={selected.id === DEFAULT_PROJECT_ID || counts.total > 0}>删除空项目</Button>
+            </Popconfirm>
+            {selected.id === DEFAULT_PROJECT_ID && <span>默认项目不能归档或删除</span>}
+            {selected.id !== DEFAULT_PROJECT_ID && counts.total > 0 && <span>含 {counts.total} 项任务，不能删除</span>}
+          </Space>
+        </Space>
+      )}
+    </Modal>
+  );
+};

--- a/src/components/ProjectSwitcher.tsx
+++ b/src/components/ProjectSwitcher.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import { Button, Input, Modal, Select, Space, message } from 'antd';
-import { PlusOutlined } from '@ant-design/icons';
+import { PlusOutlined, SettingOutlined } from '@ant-design/icons';
 import { useProjectStore } from '../store/useProjectStore';
+import { ProjectManagementModal } from './ProjectManagementModal';
 
 export const ProjectSwitcher: React.FC = () => {
   const { projects, activeProjectId, selectProject, addProject } = useProjectStore();
   const [open, setOpen] = useState(false);
+  const [manageOpen, setManageOpen] = useState(false);
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const create = async () => {
@@ -25,11 +27,13 @@ export const ProjectSwitcher: React.FC = () => {
           options={projects.filter((project) => !project.archived).map((project) => ({ value: project.id, label: project.name }))}
         />
         <Button size="small" icon={<PlusOutlined />} title="新建项目" onClick={() => setOpen(true)} />
+        <Button size="small" icon={<SettingOutlined />} title="管理项目" aria-label="管理项目" onClick={() => setManageOpen(true)} />
       </Space.Compact>
       <Modal title="新建项目" open={open} onOk={() => void create()} onCancel={() => setOpen(false)} okText="创建" cancelText="取消">
         <Input value={name} onChange={(event) => setName(event.target.value)} placeholder="项目名称" autoFocus style={{ marginBottom: 12 }} />
         <Input.TextArea value={description} onChange={(event) => setDescription(event.target.value)} placeholder="项目说明" rows={3} />
       </Modal>
+      <ProjectManagementModal open={manageOpen} onClose={() => setManageOpen(false)} />
     </>
   );
 };

--- a/src/components/TaskConsole.tsx
+++ b/src/components/TaskConsole.tsx
@@ -136,6 +136,7 @@ const TaskConsole: React.FC = () => {
     processQueue,
   } = useTaskStore();
   const activeProjectId = useProjectStore((state) => state.activeProjectId);
+  const activeProject = useProjectStore((state) => state.projects.find((project) => project.id === state.activeProjectId));
   const tasks = allTasks.filter((task) => (task.projectId || 'default-project') === activeProjectId);
 
   const accounts = useAccountStore((s) => s.accounts);
@@ -662,23 +663,13 @@ const TaskConsole: React.FC = () => {
       )}
       {/* 顶部操作栏 */}
       <div className="task-console-header">
-        <span className="task-console-title">任务调度</span>
+        <Tooltip title={`项目 ID：${activeProjectId}`}>
+          <span className="task-console-title">任务调度 · {activeProject?.name || activeProjectId}</span>
+        </Tooltip>
         <div className="task-console-stats">
-          {runningCount > 0 && (
-            <span className="stat-badge running">
-              <LoadingOutlined spin /> {runningCount}
-            </span>
-          )}
-          {queuedCount > 0 && (
-            <span className="stat-badge queued">
-              <ClockCircleOutlined /> {queuedCount}
-            </span>
-          )}
-          {doneCount > 0 && (
-            <span className="stat-badge done">
-              <CheckCircleOutlined /> {doneCount}
-            </span>
-          )}
+          <span className="stat-badge running"><LoadingOutlined spin={runningCount > 0} /> 运行 {runningCount}</span>
+          <span className="stat-badge queued"><ClockCircleOutlined /> 排队 {queuedCount}</span>
+          <span className="stat-badge done"><CheckCircleOutlined /> 完成 {doneCount}</span>
           {failCount > 0 && (
             <span className="stat-badge fail">
               <CloseCircleOutlined /> {failCount}

--- a/src/store/useProjectStore.ts
+++ b/src/store/useProjectStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import type { Project } from '../types';
+import type { ProjectOperationResult, ProjectResult } from '@doubao-studio/contracts';
 
 interface ProjectState {
   projects: Project[];
@@ -8,8 +9,8 @@ interface ProjectState {
   loadProjects: () => Promise<void>;
   selectProject: (id: string) => void;
   addProject: (name: string, description?: string) => Promise<boolean>;
-  updateProject: (id: string, updates: Partial<Pick<Project, 'name' | 'description' | 'color' | 'archived'>>) => Promise<boolean>;
-  deleteProject: (id: string) => Promise<boolean>;
+  updateProject: (id: string, updates: Partial<Pick<Project, 'name' | 'description' | 'color' | 'archived'>>) => Promise<ProjectResult>;
+  deleteProject: (id: string) => Promise<ProjectOperationResult>;
 }
 
 export const useProjectStore = create<ProjectState>((set, get) => ({
@@ -34,14 +35,19 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   },
   updateProject: async (id, updates) => {
     const result = await window.electronAPI.projects.update(id, updates);
-    if (!result.success || !result.project) return false;
+    if (!result.success || !result.project) return result;
     set({ projects: get().projects.map((project) => project.id === id ? result.project! : project) });
-    return true;
+    if (result.project.archived && get().activeProjectId === id) {
+      localStorage.setItem('doubao-studio-active-project', 'default-project');
+      set({ activeProjectId: 'default-project' });
+    }
+    return result;
   },
   deleteProject: async (id) => {
     const result = await window.electronAPI.projects.delete(id);
-    if (!result.success) return false;
+    if (!result.success) return result;
     set({ projects: get().projects.filter((project) => project.id !== id), activeProjectId: 'default-project' });
-    return true;
+    localStorage.setItem('doubao-studio-active-project', 'default-project');
+    return result;
   },
 }));

--- a/tests/unit/csvProductionExperience.test.ts
+++ b/tests/unit/csvProductionExperience.test.ts
@@ -28,8 +28,10 @@ describe('CSV 拖放与显式 CLI 导入', () => {
 
   it('import-csv 复用 TaskService 写入任务，并保持完整提示词', () => {
     const tasksFile = join(dir, 'tasks.json');
+    const projectsFile = join(dir, 'projects.json');
     const csvFile = join(dir, 'batch.csv');
     writeFileSync(tasksFile, '[]', 'utf8');
+    writeFileSync(projectsFile, JSON.stringify([{ id: 'default-project', name: '默认项目', description: '', color: '#fff', archived: false, createdAt: '', updatedAt: '' }]), 'utf8');
     writeFileSync(csvFile, 'prompt,mode\n"Line 1, spoken: ""Hello""",video', 'utf8');
     const output: string[] = [];
     const result = runCli(['import-csv', '--csv', csvFile, '--tasks-file', tasksFile], (line) => output.push(line));

--- a/tests/unit/projectCsvVisibility.test.ts
+++ b/tests/unit/projectCsvVisibility.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Project, Task } from '@doubao-studio/contracts';
+import { runCli } from '../../main/cli/doubaoCliEntry';
+import { createProjectInFile, FROZEN_MIGRATION, migrateProjectTasks } from '../../main/cli/projectTaskMigration';
+import { deleteProjectRecord, updateProjectRecord } from '../../main/utils/projectManagement';
+
+let dir: string;
+let tasksFile: string;
+let projectsFile: string;
+let csvFile: string;
+
+function project(id: string, name = id): Project {
+  return { id, name, description: '', color: '#fff', archived: false, createdAt: '2026-08-27T00:00:00.000Z', updatedAt: '2026-08-27T00:00:00.000Z' };
+}
+
+function task(id: string, projectId: string, status: Task['status'] = 'queued', mode: Task['mode'] = 'video'): Task {
+  return {
+    id, prompt: `prompt-${id}`, assignedAccountId: null, status, mode, result: null, outputs: [], artifacts: [], runHistory: [],
+    source: 'csv', dependsOnTaskIds: [], projectId, createdAt: '2026-08-27T00:00:00.000Z', updatedAt: '2026-08-27T00:00:00.000Z',
+  } as Task;
+}
+
+function writeProjects(extra: Project[] = []): void {
+  writeFileSync(projectsFile, JSON.stringify([project('default-project', '默认项目'), ...extra], null, 2), 'utf8');
+}
+
+function migrationTasks(): Task[] {
+  return [
+    ...Array.from({ length: 12 }, (_, index) => task(`source-${index}`, FROZEN_MIGRATION.sourceProjectId)),
+    ...Array.from({ length: 4 }, (_, index) => task(`c03-${index}`, 'default-project', 'done')),
+  ];
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'doubao-project-visibility-'));
+  tasksFile = join(dir, 'tasks.json');
+  projectsFile = join(dir, 'projects.json');
+  csvFile = join(dir, 'batch.csv');
+  writeFileSync(tasksFile, '[]', 'utf8');
+  writeProjects([project(FROZEN_MIGRATION.targetProjectId, '猫抓板')]);
+  writeFileSync(csvFile, 'prompt,mode,attachments\n"secret prompt",video,"D:\\\\secret\\\\asset.png"', 'utf8');
+});
+
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe('CLI CSV 项目完整性', () => {
+  it('未知 projectId 返回 PROJECT_NOT_FOUND 且台账原文不变', () => {
+    const before = readFileSync(tasksFile, 'utf8');
+    const result = runCli(['import-csv', '--csv', csvFile, '--tasks-file', tasksFile, '--projects-file', projectsFile, '--project-id', 'missing'], () => {});
+    expect(JSON.parse(result.output)).toEqual({ ok: false, error: 'PROJECT_NOT_FOUND' });
+    expect(readFileSync(tasksFile, 'utf8')).toBe(before);
+  });
+
+  it('已存在项目导入成功，机器输出不含任务、提示词或素材路径', () => {
+    const output: string[] = [];
+    const result = runCli(['import-csv', '--csv', csvFile, '--tasks-file', tasksFile, '--projects-file', projectsFile, '--project-id', FROZEN_MIGRATION.targetProjectId], (line) => output.push(line));
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(output[0]);
+    expect(parsed.data).toMatchObject({ imported: 1, skipped: 0, projectId: FROZEN_MIGRATION.targetProjectId });
+    expect(parsed.data).not.toHaveProperty('tasks');
+    expect(output[0]).not.toContain('secret prompt');
+    expect(output[0]).not.toContain('asset.png');
+    expect((JSON.parse(readFileSync(tasksFile, 'utf8')) as Task[])[0].projectId).toBe(FROZEN_MIGRATION.targetProjectId);
+  });
+
+  it('--project-name 每次创建真实 UUID，同名不复用', () => {
+    const first = createProjectInFile(projectsFile, '同名项目');
+    const second = createProjectInFile(projectsFile, '同名项目');
+    expect(first.id).not.toBe(second.id);
+    expect(first.name).toBe(second.name);
+  });
+
+  it('--project-name 创建项目后导入并返回真实项目 ID', () => {
+    const result = runCli(['import-csv', '--csv', csvFile, '--tasks-file', tasksFile, '--projects-file', projectsFile, '--project-name', '新项目'], () => {});
+    const parsed = JSON.parse(result.output);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data.projectId).toMatch(/^[0-9a-f-]{36}$/);
+    expect((JSON.parse(readFileSync(tasksFile, 'utf8')) as Task[])[0].projectId).toBe(parsed.data.projectId);
+  });
+
+  it('project-id 与 project-name 同时出现时 fail-closed', () => {
+    const before = readFileSync(tasksFile, 'utf8');
+    const result = runCli(['import-csv', '--csv', csvFile, '--tasks-file', tasksFile, '--projects-file', projectsFile, '--project-id', 'default-project', '--project-name', '冲突'], () => {});
+    expect(JSON.parse(result.output).error).toBe('INVALID_ARGUMENTS');
+    expect(readFileSync(tasksFile, 'utf8')).toBe(before);
+  });
+});
+
+describe('一次性孤儿任务迁移', () => {
+  beforeEach(() => writeFileSync(tasksFile, JSON.stringify(migrationTasks(), null, 2), 'utf8'));
+
+  const params = () => ({
+    tasksFile, projectsFile,
+    sourceProjectId: FROZEN_MIGRATION.sourceProjectId,
+    targetProjectId: FROZEN_MIGRATION.targetProjectId,
+  });
+
+  it('默认 dry-run 只报告12项且不写入', () => {
+    const before = readFileSync(tasksFile, 'utf8');
+    expect(migrateProjectTasks(params())).toMatchObject({ dryRun: true, affected: 12, targetQueuedVideoAfter: 12 });
+    expect(readFileSync(tasksFile, 'utf8')).toBe(before);
+  });
+
+  it('非冻结来源或目标被拒绝', () => {
+    expect(() => migrateProjectTasks({ ...params(), sourceProjectId: 'other' })).toThrow('MIGRATION_SCOPE_NOT_ALLOWED');
+  });
+
+  it('明确确认后迁移，source=0、target=12、默认4项完整不变', () => {
+    const beforeDefault = migrationTasks().filter((item) => item.projectId === 'default-project');
+    expect(migrateProjectTasks({ ...params(), confirm: 12 })).toMatchObject({ dryRun: false, sourceQueuedVideoAfter: 0, targetQueuedVideoAfter: 12, defaultDoneAfter: 4 });
+    const after = JSON.parse(readFileSync(tasksFile, 'utf8')) as Task[];
+    expect(after.filter((item) => item.projectId === FROZEN_MIGRATION.sourceProjectId)).toHaveLength(0);
+    expect(after.filter((item) => item.projectId === FROZEN_MIGRATION.targetProjectId)).toHaveLength(12);
+    expect(after.filter((item) => item.projectId === 'default-project')).toEqual(beforeDefault);
+  });
+
+  it('tasks.json 在读后漂移时拒绝覆盖', () => {
+    expect(() => migrateProjectTasks({
+      ...params(), confirm: 12,
+      beforeWrite: () => writeFileSync(tasksFile, JSON.stringify([...migrationTasks(), task('external', 'default-project')]), 'utf8'),
+    })).toThrow('TASKS_FILE_CHANGED');
+    expect((JSON.parse(readFileSync(tasksFile, 'utf8')) as Task[]).some((item) => item.id === 'external')).toBe(true);
+  });
+
+  it.each([
+    ['source count', () => migrationTasks().slice(1)],
+    ['source status', () => migrationTasks().map((item, index) => index === 0 ? { ...item, status: 'fail' as const } : item)],
+    ['target nonempty', () => [...migrationTasks(), task('target-existing', FROZEN_MIGRATION.targetProjectId)]],
+  ])('%s 不变量不符时拒绝写入', (_label, factory) => {
+    const value = factory();
+    writeFileSync(tasksFile, JSON.stringify(value), 'utf8');
+    expect(() => migrateProjectTasks({ ...params(), confirm: 12 })).toThrow();
+    expect(JSON.parse(readFileSync(tasksFile, 'utf8'))).toEqual(value);
+  });
+});
+
+describe('安全项目管理规则', () => {
+  const projects = [project('default-project'), project('active')];
+
+  it('默认项目不能删除或归档', () => {
+    expect(deleteProjectRecord(projects, [], 'default-project').success).toBe(false);
+    expect(updateProjectRecord(projects, 'default-project', { archived: true }).success).toBe(false);
+  });
+
+  it('含任务项目返回 taskCount 并拒绝删除', () => {
+    expect(deleteProjectRecord(projects, [task('1', 'active'), task('2', 'active')], 'active')).toMatchObject({ success: false, taskCount: 2 });
+  });
+
+  it('空项目可删除且不触碰任务', () => {
+    const result = deleteProjectRecord(projects, [task('1', 'default-project')], 'active');
+    expect(result).toMatchObject({ success: true, taskCount: 0 });
+    if (result.success) expect(result.projects.map((item) => item.id)).toEqual(['default-project']);
+  });
+
+  it('编辑只接受安全字段并拒绝空名称', () => {
+    expect(updateProjectRecord(projects, 'active', { name: '  新名称  ', description: '  说明  ' })).toMatchObject({ success: true, project: { name: '新名称', description: '说明' } });
+    expect(updateProjectRecord(projects, 'active', { name: '   ' }).success).toBe(false);
+  });
+});
+
+describe('项目管理界面源码契约', () => {
+  it('暴露管理入口、二次确认与始终可见的项目统计', () => {
+    const switcher = readFileSync(join(process.cwd(), 'src/components/ProjectSwitcher.tsx'), 'utf8');
+    const modal = readFileSync(join(process.cwd(), 'src/components/ProjectManagementModal.tsx'), 'utf8');
+    const consoleSource = readFileSync(join(process.cwd(), 'src/components/TaskConsole.tsx'), 'utf8');
+    expect(switcher).toContain('管理项目');
+    expect(modal).toContain('Popconfirm');
+    expect(modal).toContain('不能删除');
+    expect(consoleSource).toContain('排队 {queuedCount}');
+    expect(consoleSource).toContain('运行 {runningCount}');
+    expect(consoleSource).toContain('完成 {doneCount}');
+  });
+});


### PR DESCRIPTION
## Summary
- fail closed when CLI CSV import targets an unknown project
- add controlled orphan-task migration with fingerprint and atomic-write guards
- add safe project management and per-project task counts

## Validation
- pnpm run validate
- 38 files / 886 tests passed
- TypeScript, project/contracts checks, renderer/main builds passed
- ESLint 0 errors / 142 warnings

No platform submission, credential, session, or video artifact changes.