### PR TITLE
feat(automation): persist accepted observation pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ flowchart LR
 - 从 CSV 批量导入提示词、模式、视频模型、时长、比例、素材和账号。
 - 可点击 CSV 按钮选择文件，也可把单个 `.csv` 文件直接拖到任务调度区；导入结果会明确显示成功、跳过和未指派数量。
 - 使用 `depends_on` 指定前置 CSV 行号，多个行号使用 `|` 分隔。
-- `all_done` 要求所有前置任务成功；`all_finished` 允许前置任务失败后继续。
+- `all_done` 要求所有前置任务成功；`all_accepted` 在所有前置任务获得平台明确受理并建立可恢复观察绑定后放行；`all_finished` 允许前置任务失败后继续。
 - 任务批次页面汇总总数、进度、运行、排队和失败数量。
 - 可对整个批次中的失败任务一键重新排队。
 
@@ -217,7 +217,7 @@ CSV 模板见 [`examples/tasks-template.csv`](examples/tasks-template.csv)。
 | `ratio` | 画面比例 | `9:16` |
 | `reference_images` | 参考图片绝对路径；多值按模板规则填写 | `D:\assets\hero.png` |
 | `depends_on` | 前置 CSV 行号，多个使用 `|` 分隔 | `1|2` |
-| `dependency_policy` | `all_done` 或 `all_finished` | `all_done` |
+| `dependency_policy` | `all_done`、`all_accepted` 或 `all_finished` | `all_done` |
 
 > [!CAUTION]
 > `import-csv` CLI 会写入项目和任务数据。必须先退出豆包工作室，再显式提供真实 `tasks.json` 与同目录 `projects.json`；不要让桌面程序与 CLI 同时写同一数据文件，也不要猜测历史工作树中的数据路径。`--project-id` 必须是真实 ID；如需新项目，使用 `--project-name` 创建，不要把项目名称填入 `--project-id`。

--- a/docs/handoffs/2026-09-10-doubao-accepted-observation-pipeline-01-r1.md
+++ b/docs/handoffs/2026-09-10-doubao-accepted-observation-pipeline-01-r1.md
@@ -1,0 +1,42 @@
+# DOUBAO-ACCEPTED-OBSERVATION-PIPELINE-01 R1 验收收口单
+
+- 日期：2026-09-10
+- 裁决：PASS after R1
+- supersedes：`2026-09-10-doubao-accepted-observation-pipeline-01.md` 的“未人工验收”状态
+- 基线：`origin/main@dfbb7f2028bd88caf838c52f5785e3130e594e7a`
+
+## R1 阻断与修复
+
+首次真实多账号验收发现：前置任务已有合法 `acceptanceObservation.outcome=observing`，跨账号 `all_accepted` 后继仍长期 queued。账号、额度、依赖关系均正常，阻断定位为启动期与软阻断状态缺少可靠调度触发。
+
+R1 仅修复该核心承诺失败：
+
+1. `src/App.tsx` 在账号、项目、任务加载完成后显式执行一次队列评估。
+2. `src/store/useTaskStore.ts` 对 availability=unknown 的目标账号发起有界复检与退避调度，不再永久跳过。
+3. 同账号串行保护扩大为任意 `acceptanceObservation.outcome=observing`，覆盖生成确认等受理后状态。
+
+## 门禁与真实验收
+
+- 包3全量 `pnpm run validate`：PASS，49 files / 1013 tests；TypeScript、工程/Contracts 边界、Renderer/Main build PASS。
+- 包3 `pnpm run pack`：PASS。
+- 包2→包3联合候选：49 files / 1030 tests；TypeScript、lint、build、pack、`git diff --check` 全 PASS。
+- 单任务真实链：一次普通 5 秒视频，仅提交一次；重启后沿同一具体会话只读恢复；产物 `artifact-d46a8e96` 正确绑定；observation 最终 completed。
+- 跨账号：前置任务受理并 observing 后，不同账号后继由 queued 自动进入 executing/new_conversation。
+- 同账号：后继保持 queued，串行保护生效。
+- 复验后两个后继均通过本机控制面立即取消，未发生额外提交或重复额度消耗。
+
+权威证据：`D:\豆包工作室\_acceptance\p2-p3-20260910-204549\final-acceptance.json`；相关原始日志为 `p3-fix-validate.log`、`g6-result.json`、`g6e-monitor.log`。
+
+## 文件与纪律
+
+R1 在原 18 文件基础上新增 tracked 修改 `src/App.tsx`，并新增本收口单；本工作树提交候选共 20 项：16 tracked 修改、4 untracked 新增；无 tracked 删除。未包含验收目录、临时用户数据、Cookie、Token、Session、真实任务台账或视频产物。
+
+## 五态声明
+
+- 已实现：是。
+- CI：尚未运行远端 CI。
+- 人工/真实验收：PASS。
+- 已合并：否。
+- 已部署/已发布：否。
+
+Dola 仍未验证。后续必须先合并第二包，再把本包集成到新的 main 并重跑联合门禁。

--- a/docs/handoffs/2026-09-10-doubao-accepted-observation-pipeline-01.md
+++ b/docs/handoffs/2026-09-10-doubao-accepted-observation-pipeline-01.md
@@ -1,0 +1,103 @@
+# DOUBAO-ACCEPTED-OBSERVATION-PIPELINE-01 实施交接单
+
+- 日期：2026-09-10
+- 状态：代码已实现、自动化测试通过；未人工验收、未执行真实任务、未提交、未推送、未部署
+- 工作树：`D:\豆包工作室\doubao-accepted-observation-pipeline-01`
+- 分支：`codex/doubao-accepted-observation-pipeline-01`
+- 基线：`origin/main@dfbb7f2028bd88caf838c52f5785e3130e594e7a`
+- HEAD：`dfbb7f2028bd88caf838c52f5785e3130e594e7a`（全部变更仍未暂存、未提交）
+
+## 治理与冻结验收包
+
+开工前已读取总架构师治理规则、中央 memory、豆包 `AGENTS.md`、README、ROADMAP、DESIGN、2026-09-08 生产使用报告、第二包 handoff 及相关源码测试。仓库没有 `docs/memory/`，未为凑数创建。
+
+本包冻结为三个 P0：
+
+1. 新增 `all_accepted`，不改变 `all_done` / `all_finished` 旧语义；仅“平台明确受理 + 同 run 的 observing 绑定”或历史 done 可满足。
+2. 在平台受理后、触发队列前，原子写入并回读脱敏观察绑定；失败进入防重发暂停。
+3. 同账号观察期间保持串行，不同账号可在受理后并行；重启/切页沿原会话只读恢复，产物完成时原子绑定 artifact ID 并收口观察。
+
+非目标：未改页面控件就绪状态机、执行意图、local-control/下载端点、批量下载 UI 或 P1 错误码；未操作真实平台。Dola 仍未完成真实验收，不宣称可用。
+
+## 实施结果
+
+### P0-1：`all_accepted`
+
+- Contracts、CSV、持久化归一化和 README/模板均识别 `all_accepted`。
+- `submittedAt`、`generating` 或 `submission_uncertain` 本身均不算受理。
+- 旧 `done` 任务兼容；带有效观察绑定的已受理任务即使之后观察失败，仍满足“已受理”，但该任务自身禁止重发。
+
+### P0-2：受理观察绑定
+
+- 新增 `acceptanceObservation`：账号、run、原会话 URL、受理时间、最小证据、轮询游标、预期产物、观察租约和 outcome。
+- 不保存提示词、页面全文、素材路径、Cookie、Token 或 Session。
+- BrowserPanel 只在 `classifySubmissionReadback(...) === confirmed` 后创建绑定。
+- 顺序固定为：构造绑定 → 单次 `updateTaskRuntime(status=generating)` → Store 回读核对 → `setAccountAutomationState(generating)` 触发后续调度。
+- 写入失败或回读不一致抛 `SubmissionSafetyPauseError`，保留提交意图并禁止自动重发。
+
+### P0-3：恢复、串并行与产物收口
+
+- 同账号存在 observing 任务时，调度器主动跳过该账号；其他账号仍可运行。
+- Main 启动恢复和 Renderer reload 均把带有效绑定的 generating 转入 `manual_submission_observing`，清执行锁、不结束 runHistory。
+- Webview 就绪后复用既有 `reconcile-task-submission` 只读路径，沿持久化原会话恢复，不新增发送链路。
+- 观察租约按已有 15 秒运行快照节流续期；恢复观察时先续租。
+- 观察阶段异常转入只读观察，不记普通账号失败、不开放 retry。
+- `TaskService.updateStatus(done, outputs)` 使用单一时间源，在同一次 Repository replace 中生成 artifact、写 artifact ID、标记 observation completed。
+
+## 文件清单
+
+Tracked 修改（15）：
+
+- `README.md`
+- `examples/tasks-template.csv`
+- `main/core/TaskService.ts`
+- `main/utils/persistenceNormalization.ts`
+- `packages/contracts/src/domain.ts`
+- `packages/contracts/src/enums.ts`
+- `src/components/BrowserPanel.tsx`
+- `src/store/useTaskStore.ts`
+- `src/utils/dependencyEval.ts`
+- `src/utils/realSendStateMachine.ts`
+- `tests/unit/contracts.test.ts`
+- `tests/unit/dependencyEval.test.ts`
+- `tests/unit/persistenceNormalization.test.ts`
+- `tests/unit/real-send-recovery.test.ts`
+- `tests/unit/taskService.test.ts`
+
+Untracked 新增（3）：
+
+- `src/utils/acceptedObservation.ts`
+- `tests/unit/acceptedObservation.test.ts`
+- `docs/handoffs/2026-09-10-doubao-accepted-observation-pipeline-01.md`
+
+Tracked 删除：无。
+
+共 18 文件，未越过冻结 allowlist 的 20% 停止线。
+
+## 门禁证据
+
+- 专项：6 files / 380 tests pass / 0 fail。
+- TypeScript：`pnpm run ts-check` PASS。
+- 修改文件 ESLint：0 error；告警均为既有类别。
+- `git diff --check`：PASS（仅 Git 的 LF→CRLF 工作树提示，无空白错误）。
+- 全量 `pnpm run validate`：PASS，exit code 0。
+  - 全量测试：49 files / 1013 tests pass / 0 fail。
+  - 全量 ESLint：0 error / 146 warnings，低于 149 上限。
+  - 工程 fixture、Contracts 边界、Renderer build、Main build：PASS。
+
+## 合并顺序与待验收
+
+第二包 `DOUBAO-VIDEO-PAGE-READINESS-01` 仍位于独立未提交工作树，并与本包在 Contracts、BrowserPanel、持久化归一化等文件有重叠。本包后续候选提交/合并必须排在第二包之后，并人工处理冲突、重跑完整门禁；不得直接覆盖第二包实现。
+
+真实验收需后续单独授权一次普通 5 秒视频，至少验证：不同账号 `all_accepted` 放行、同账号不放行、重启后原会话恢复、单次提交、正确产物绑定且无重复额度消耗。本轮未执行该验收。
+
+## 纪律声明
+
+未暂存、未提交、未推送、未创建或修改 PR；未部署、未发布、未启动或重启豆包工作室；未上传素材、未提交真实视频、未消耗额度；未触碰 Cookie、Token、账号 Session、运行数据、视频产物及其他工作树的未提交现场。
+
+## 验收修复 R1：all_accepted 真实多账号放行
+- R1 修复 all_accepted 启动/重启放行与同账号串行判定。
+- 触发：前置任务已取得 `acceptanceObservation.outcome=observing`，跨账号后继仍 queued。
+- 修复：启动队列评估、unknown 可用性退避复检、同账号 observing 串行。
+- 门禁：pnpm run validate PASS，49 files / 1013 tests；pack PASS。
+- 真实复验：跨账号后继自动 queued→executing/new_conversation；同账号后继保持 queued；随后取消，未重复提交。

--- a/examples/tasks-template.csv
+++ b/examples/tasks-template.csv
@@ -1,4 +1,4 @@
 prompt,mode,model,duration,aspect_ratio,attachments,audio,account,depends_on,dependency_policy
 "生成一张电影感产品主图，主体居中，柔和自然光",image,,,,"D:\素材\产品正面.jpg",,,,
 "让参考图片中的产品缓慢旋转，镜头轻微推进",video,seedance-2.0,10s,16:9,"D:\素材\产品正面.jpg",,"工作号-01",2,all_done
-"为产品视频编写简短发布文案",chat,,,,,,,3,all_finished
+"为产品视频编写简短发布文案",chat,,,,,,,3,all_accepted

--- a/main/core/TaskService.ts
+++ b/main/core/TaskService.ts
@@ -52,6 +52,7 @@ export interface TaskRecoverySummary {
 const LEGACY_UNCERTAIN_SUBMISSION = /发送按钮不可用|点击结果不确定|发送动作结果不确定|发送状态不确定|人工核对豆包会话/;
 
 function requiresSubmissionReconciliation(task: Task): boolean {
+  if (task.runtime?.acceptanceObservation?.outcome === 'observing') return true;
   if (task.status === 'waiting_generation_confirmation' || task.status === 'manual_submission_observing') return true;
   if (!task.runtime?.submittedAt) return false;
   if (!['paused', 'waiting_verification', 'waiting_generation_confirmation', 'manual_submission_observing', 'fail', 'cancelled'].includes(task.status)) return false;
@@ -257,6 +258,7 @@ export class TaskService {
     if (!task) return { success: false, error: '任务不存在' };
     task.status = params.status;
     if (params.result !== undefined) task.result = params.result;
+    const timestamp = this.now();
     if (params.outputs !== undefined) {
       task.outputs = [...new Set(params.outputs.filter(Boolean))];
       const existing = new Map((task.artifacts || []).map((artifact) => [artifact.url, artifact]));
@@ -265,13 +267,30 @@ export class TaskService {
           id: artifactId(url), url,
           kind: task.mode === 'video' ? 'video' : task.mode === 'image' ? 'image' : 'file',
           source: 'network', runId: task.runtime?.runId,
-          conversationUrl: task.runtime?.conversationUrl, discoveredAt: this.now(),
+          conversationUrl: task.runtime?.conversationUrl, discoveredAt: timestamp,
         });
       }
       task.artifacts = [...existing.values()];
     }
-    if (params.status === 'done') task.errorInfo = undefined;
-    task.updatedAt = this.now();
+    if (params.status === 'done') {
+      task.errorInfo = undefined;
+      const runtime = task.runtime;
+      const observation = runtime?.acceptanceObservation;
+      const artifact = task.artifacts?.find((item) => item.runId === task.runtime?.runId) || task.artifacts?.[0];
+      if (runtime && observation && artifact) {
+        task.runtime = {
+          ...runtime,
+          acceptanceObservation: {
+            ...observation,
+            expectedArtifact: { ...observation.expectedArtifact, artifactId: artifact.id },
+            lease: { ...observation.lease, lastHeartbeatAt: timestamp, expiresAt: timestamp },
+            outcome: 'completed',
+            completedAt: timestamp,
+          },
+        };
+      }
+    }
+    task.updatedAt = timestamp;
     if (!this.persist(tasks)) return { success: false, error: WRITE_ERROR };
     return { success: true };
   }
@@ -342,6 +361,29 @@ export class TaskService {
     let changed = false;
 
     for (const task of tasks) {
+      const acceptedObservation = task.runtime?.acceptanceObservation;
+      if (task.status === 'generating' && acceptedObservation?.outcome === 'observing' &&
+        acceptedObservation.runId === task.runtime?.runId) {
+        task.status = 'manual_submission_observing';
+        task.result = '程序重启，正在从原会话恢复只读产物观察';
+        task.runtime = {
+          ...task.runtime,
+          stage: 'manual_submission_observing',
+          message: task.result,
+          stageStartedAt: timestamp,
+          lastHeartbeatAt: timestamp,
+          acceptanceObservation: {
+            ...acceptedObservation,
+            lease: { ...acceptedObservation.lease, lastHeartbeatAt: timestamp, expiresAt: timestamp },
+          },
+        };
+        task.updatedAt = timestamp;
+        if (task.lock) clearedLocks++;
+        task.lock = undefined;
+        recoveredTasks++;
+        changed = true;
+        continue;
+      }
       if (task.status === 'waiting_generation_confirmation' || task.status === 'manual_submission_observing') {
         if (task.lock) {
           task.lock = undefined;
@@ -554,7 +596,7 @@ export class TaskService {
       videoConfig: Task['videoConfig'];
       attachments: string[] | undefined;
       audioAttachment: string | undefined;
-      dependencyPolicy: 'all_done' | 'all_finished';
+      dependencyPolicy: 'all_done' | 'all_accepted' | 'all_finished';
       dependsOnRaw: string;
     }
     const partialTasks: CsvPartialTask[] = [];
@@ -594,7 +636,7 @@ export class TaskService {
         continue;
       }
       const rawPolicy = policyIndex >= 0 ? (row[policyIndex] || '').trim() : '';
-      if (rawPolicy && rawPolicy !== 'all_done' && rawPolicy !== 'all_finished') {
+      if (rawPolicy && rawPolicy !== 'all_done' && rawPolicy !== 'all_accepted' && rawPolicy !== 'all_finished') {
         errors.push(`第 ${dataIndex + 1} 行：依赖策略「${rawPolicy}」无效`);
         continue;
       }
@@ -612,7 +654,7 @@ export class TaskService {
           ? (row[attachmentsIndex] || '').split('|').map((item) => item.trim()).filter(Boolean)
           : undefined,
         audioAttachment: audioIndex >= 0 ? (row[audioIndex] || '').trim() || undefined : undefined,
-        dependencyPolicy: rawPolicy === 'all_finished' ? 'all_finished' : 'all_done',
+        dependencyPolicy: rawPolicy === 'all_finished' ? 'all_finished' : rawPolicy === 'all_accepted' ? 'all_accepted' : 'all_done',
         dependsOnRaw: dependsIndex >= 0 ? (row[dependsIndex] || '') : '',
       });
       sourceRows.push(dataIndex + 1);

--- a/main/utils/persistenceNormalization.ts
+++ b/main/utils/persistenceNormalization.ts
@@ -64,7 +64,7 @@ const VALID_TASK_STAGES: readonly TaskStage[] = [
   'waiting_verification', 'waiting_generation_confirmation', 'manual_submission_observing', 'generating', 'extracting_outputs',
   'completed', 'paused', 'failed', 'cancelled',
 ];
-const VALID_DEPENDENCY_POLICIES: readonly DependencyPolicy[] = ['all_done', 'all_finished'];
+const VALID_DEPENDENCY_POLICIES: readonly DependencyPolicy[] = ['all_done', 'all_accepted', 'all_finished'];
 const VALID_DOWNLOAD_STATUSES = ['queued', 'downloading', 'done', 'failed'] as const;
 const VALID_ARTIFACT_KINDS = ['image', 'video', 'file'] as const;
 const VALID_ARTIFACT_SOURCES = ['network', 'page', 'manual'] as const;
@@ -421,6 +421,46 @@ function normalizeErrorInfo(raw: unknown, now: string): TaskErrorInfo | undefine
   };
 }
 
+function normalizeAcceptanceObservation(raw: unknown): TaskRunSnapshot['acceptanceObservation'] {
+  if (!isObject(raw) || raw.schemaVersion !== 1 || !isObject(raw.evidence) ||
+    !isObject(raw.cursor) || !isObject(raw.expectedArtifact) || !isObject(raw.lease)) return undefined;
+  const accountId = asNonEmptyString(raw.accountId);
+  const runId = asNonEmptyString(raw.runId);
+  const conversationUrl = asNonEmptyString(raw.conversationUrl);
+  const artifactRunId = asNonEmptyString(raw.expectedArtifact.runId);
+  const ownerId = asNonEmptyString(raw.lease.ownerId);
+  if (!accountId || !runId || !conversationUrl || !artifactRunId || !ownerId ||
+    !isValidISODate(raw.acceptedAt) || !isValidISODate(raw.lease.acquiredAt) ||
+    !isValidISODate(raw.lease.expiresAt) || !isValidISODate(raw.lease.lastHeartbeatAt)) return undefined;
+  return {
+    schemaVersion: 1,
+    accountId, runId, conversationUrl, acceptedAt: raw.acceptedAt,
+    evidence: {
+      kind: oneOf(raw.evidence.kind, ['generation_started', 'prompt_published', 'material_authorization_confirmed'] as const, 'prompt_published'),
+      messageCount: asNonNegativeNumber(raw.evidence.messageCount, 0) || undefined,
+      generationStartedAt: asNonNegativeNumber(raw.evidence.generationStartedAt, 0) || undefined,
+    },
+    cursor: {
+      messageCount: asNonNegativeNumber(raw.cursor.messageCount, 0),
+      generationStartedAt: asNonNegativeNumber(raw.cursor.generationStartedAt, 0) || undefined,
+      pollCount: asNonNegativeNumber(raw.cursor.pollCount, 0),
+    },
+    expectedArtifact: {
+      kind: oneOf(raw.expectedArtifact.kind, ['video', 'image', 'file'] as const, 'file'),
+      runId: artifactRunId,
+      artifactId: asNonEmptyString(raw.expectedArtifact.artifactId) ?? undefined,
+    },
+    lease: {
+      ownerId,
+      acquiredAt: raw.lease.acquiredAt,
+      expiresAt: raw.lease.expiresAt,
+      lastHeartbeatAt: raw.lease.lastHeartbeatAt,
+    },
+    outcome: oneOf(raw.outcome, ['observing', 'completed', 'manual_review'] as const, 'observing'),
+    completedAt: isValidISODate(raw.completedAt) ? raw.completedAt : undefined,
+  };
+}
+
 /**
  * 归一化 TaskRunSnapshot（运行快照）。
  */
@@ -440,6 +480,7 @@ function normalizeRuntime(raw: unknown, taskMode: GenerationMode, now: string): 
     lastHeartbeatAt: asISODate(r.lastHeartbeatAt, now),
     submittedAt: (() => { const v = r.submittedAt; return isValidISODate(v) ? v : undefined; })(),
     conversationUrl: asNonEmptyString(r.conversationUrl) ?? undefined,
+    acceptanceObservation: normalizeAcceptanceObservation(r.acceptanceObservation),
     controlReadiness: isObject(r.controlReadiness) ? {
       schemaVersion: r.controlReadiness.schemaVersion === 1 ? 1 : undefined,
       ready: typeof r.controlReadiness.ready === 'boolean' ? r.controlReadiness.ready : undefined,

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -131,6 +131,37 @@ export interface TaskRunSnapshot {
   lastHeartbeatAt: string;
   submittedAt?: string;
   conversationUrl?: string;
+  /** 平台明确受理后的可恢复观察绑定；不包含提示词、素材路径或账号凭据。 */
+  acceptanceObservation?: {
+    schemaVersion: 1;
+    accountId: string;
+    runId: string;
+    conversationUrl: string;
+    acceptedAt: string;
+    evidence: {
+      kind: 'generation_started' | 'prompt_published' | 'material_authorization_confirmed';
+      messageCount?: number;
+      generationStartedAt?: number;
+    };
+    cursor: {
+      messageCount: number;
+      generationStartedAt?: number;
+      pollCount: number;
+    };
+    expectedArtifact: {
+      kind: 'video' | 'image' | 'file';
+      runId: string;
+      artifactId?: string;
+    };
+    lease: {
+      ownerId: string;
+      acquiredAt: string;
+      expiresAt: string;
+      lastHeartbeatAt: string;
+    };
+    outcome: 'observing' | 'completed' | 'manual_review';
+    completedAt?: string;
+  };
   controlReadiness?: {
     schemaVersion?: 1;
     ready?: boolean;

--- a/packages/contracts/src/enums.ts
+++ b/packages/contracts/src/enums.ts
@@ -94,4 +94,4 @@ export type VideoDuration = '4s' | '5s' | '6s' | '7s' | '8s' | '9s' | '10s' | '1
 export type VideoAspectRatio = '1:1' | '3:4' | '4:3' | '9:16' | '16:9' | '21:9';
 
 /** 任务依赖策略 */
-export type DependencyPolicy = 'all_done' | 'all_finished';
+export type DependencyPolicy = 'all_done' | 'all_accepted' | 'all_finished';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,9 +63,11 @@ const App: React.FC = () => {
   // ---- 初始化加载 ----
 
   useEffect(() => {
-    loadAccounts();
-    loadProjects();
-    loadTasks(true);
+    let startupQueueTimer: ReturnType<typeof setTimeout> | undefined;
+    void Promise.all([loadAccounts(), loadProjects(), loadTasks(true)]).then(() => {
+      // 账号/任务加载完成后做一次启动队列评估；否则已满足 all_accepted 的排队任务可能没有调度事件。
+      startupQueueTimer = setTimeout(() => useTaskStore.getState().processQueue(), 0);
+    });
     let timer: ReturnType<typeof setTimeout> | undefined;
     const scheduleMidnightRefresh = () => {
       timer = setTimeout(async () => {
@@ -75,7 +77,10 @@ const App: React.FC = () => {
       }, millisecondsUntilNextLocalMidnight() + 250);
     };
     scheduleMidnightRefresh();
-    return () => { if (timer) clearTimeout(timer); };
+    return () => {
+      if (timer) clearTimeout(timer);
+      if (startupQueueTimer) clearTimeout(startupQueueTimer);
+    };
   }, [loadAccounts, loadProjects, loadTasks, refreshDailyQuota]);
 
   // 本机控制面只通过稳定 ID 调用现有调度边界；不暴露 DOM/webview/页面会话。

--- a/src/components/BrowserPanel.tsx
+++ b/src/components/BrowserPanel.tsx
@@ -56,6 +56,7 @@ import {
   matchesSubmissionConversation,
   requiresSubmissionReconciliation,
   updateStableStreak,
+  type SubmissionReadback,
 } from '../utils/realSendStateMachine';
 import { createWebviewResourceScope } from '../utils/webviewLifecycle';
 import type { WebviewResourceScope } from '../utils/webviewLifecycle';
@@ -65,6 +66,7 @@ import { isExperimentalNoWatermarkEnabled, setExperimentalNoWatermarkEnabled } f
 import { decideMaterialAuthorizationProgress } from '../utils/materialAuthorization';
 import { selectQuotaFallbackAccount } from '../utils/quotaRecovery';
 import type { GenerationConfirmationEvidence } from '../utils/generationConfirmation';
+import { createAcceptedObservationBinding, renewObservationLease } from '../utils/acceptedObservation';
 import { createVideoReadinessCheckpoint, VideoControlReadinessError } from '../utils/videoControlReadiness';
 import type { VideoControlReadinessResult, VideoPageReadinessStage } from '../utils/videoControlReadiness';
 import { initializationGate } from '../utils/initializationGate';
@@ -433,6 +435,14 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
       useAccountStore.getState().selectAccount(accountId);
       useTaskStore.getState().setAccountAutomationState(accountId, 'generating', '正在核对平台结果（不会重新发送）...');
       try {
+        if (task.runtime?.acceptanceObservation?.outcome === 'observing') {
+          const heartbeatAt = new Date().toISOString();
+          const renewed = renewObservationLease(task.runtime.acceptanceObservation, heartbeatAt, 60_000);
+          const renewedOk = await useTaskStore.getState().updateTaskRuntime(taskId, {
+            runtime: { acceptanceObservation: renewed, lastHeartbeatAt: heartbeatAt },
+          });
+          if (!renewedOk) throw new Error('观察租约续期失败');
+        }
         const currentUrl = webview.getURL();
         // 只允许回到台账在原提交链中保存的会话 URL。即使同账号 WebView 当前停在
         // 另一个具体会话，也不得把它猜作目标会话，避免错绑产物或间接放开重发。
@@ -1123,6 +1133,17 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
     });
   }, [accountBusy, executingTasks, tasks, webviewEpoch]);
 
+  // 应用重启或页面重新挂载后，只沿已持久化的原会话恢复观察；不进入注入/发送流程。
+  useEffect(() => {
+    tasks.forEach((task) => {
+      if (task.status !== 'manual_submission_observing' ||
+        task.runtime?.acceptanceObservation?.outcome !== 'observing' ||
+        !task.assignedAccountId || !registryRef.current.has(task.assignedAccountId) ||
+        submissionReconcileRef.current.has(task.id)) return;
+      window.dispatchEvent(new CustomEvent('reconcile-task-submission', { detail: { taskId: task.id } }));
+    });
+  }, [tasks, webviewEpoch]);
+
   // ---- 自动化执行 ----
   const executeAutomation = async (
     accountId: string,
@@ -1613,11 +1634,13 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
       }
 
       let submissionConfirmed = false;
+      let confirmedEvidence: SubmissionReadback | undefined;
       for (let attempt = 0; attempt < 4; attempt++) {
         await pause(500);
         const evidence = await getSubmissionEvidence(webview, prompt, generationStartTimeBeforeSubmit, initialMsgCount);
         if (classifySubmissionReadback(evidence) === 'confirmed') {
           submissionConfirmed = true;
+          confirmedEvidence = evidence;
           break;
         }
       }
@@ -1661,11 +1684,45 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
         throw new AccountAvailabilityPauseError('检测到机器人验证，请人工处理并核对会话；系统不会自动重新提交', 'human_verification');
       }
 
+      const acceptedAt = new Date().toISOString();
+      const acceptedTask = useTaskStore.getState().tasks.find((item) => item.id === taskId);
+      const acceptedRunId = acceptedTask?.runtime?.runId;
+      const conversationUrl = webview.getURL();
+      if (!confirmedEvidence || !acceptedRunId || !conversationUrl) {
+        throw new SubmissionSafetyPauseError('平台已受理，但无法建立完整观察绑定；系统不会自动重发');
+      }
+      const generationStartedAt = await getGenerationStartTime(webview);
+      const acceptanceObservation = createAcceptedObservationBinding({
+        accountId,
+        runId: acceptedRunId,
+        conversationUrl,
+        acceptedAt,
+        ownerId: `renderer-${acceptedRunId}`,
+        mode: mode as Task['mode'],
+        evidence: confirmedEvidence,
+        generationStartedAt,
+        materialAuthorizationConfirmed: authorizationTriggeredSubmission,
+      });
+      const observationPersisted = await updateTaskRuntime(taskId, {
+        status: 'generating',
+        result: '平台已明确受理，正在观察原会话产物',
+        errorInfo: null,
+        runtime: {
+          stage: 'generating',
+          message: '平台已明确受理，正在观察原会话产物',
+          stageStartedAt: acceptedAt,
+          lastHeartbeatAt: acceptedAt,
+          conversationUrl,
+          acceptanceObservation,
+        },
+      });
+      const persistedObservation = useTaskStore.getState().tasks.find((item) => item.id === taskId)?.runtime?.acceptanceObservation;
+      if (!observationPersisted || persistedObservation?.runId !== acceptedRunId || persistedObservation.outcome !== 'observing') {
+        throw new SubmissionSafetyPauseError('平台已受理，但观察绑定写入或回读不一致；系统不会自动重发');
+      }
+      // 只有持久化与回读成功后才触发队列；all_accepted 依赖此时才可放行其他账号。
       setAccountAutomationState(accountId, 'generating', '等待豆包生成回复...', 'generating');
       await pause(3000);
-      await updateTaskRuntime(taskId, {
-        runtime: { conversationUrl: webview.getURL(), lastHeartbeatAt: new Date().toISOString() },
-      });
 
       let generating = true;
       let imageUrls: string[] = [];
@@ -1835,6 +1892,8 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
           console.error(`[Automation:${accountId}] 视频就绪诊断持久化失败:`, persistError);
         }
       }
+      const acceptedObservationActive = useTaskStore.getState().tasks.find((item) => item.id === taskId)
+        ?.runtime?.acceptanceObservation?.outcome === 'observing';
       const errorMessage = cancelled ? '用户已取消等待' : (err.message || String(err));
       const errorInfo = controlReadinessFailure
         ? { code: err.code, message: errorMessage, recoverable: true, detectedAt: new Date().toISOString() }
@@ -1846,11 +1905,11 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
       }
       const quotaExhausted = mode === 'video' && errorInfo.code === 'quota_exhausted';
       if (quotaExhausted) await useAccountStore.getState().markSeedanceExhausted(accountId);
-      if (!cancelled && !safetyPaused && !availabilityPaused && !confirmationPaused && !controlReadinessFailure) {
+      if (!cancelled && !safetyPaused && !availabilityPaused && !confirmationPaused && !controlReadinessFailure && !acceptedObservationActive) {
         await useAccountStore.getState().recordAccountOutcome(accountId, 'failure', errorInfo.code);
       }
       console.error(`[Automation:${accountId}] ${cancelled || safetyPaused || availabilityPaused || confirmationPaused ? '已暂停' : '失败'}:`, errorMessage);
-      if (cancelled || safetyPaused || availabilityPaused || confirmationPaused) {
+      if (cancelled || safetyPaused || availabilityPaused || confirmationPaused || acceptedObservationActive) {
         const requestedCancellationStatus = pendingCancellationStatusRef.current.get(taskId);
         await pauseAutomation(
           taskId,
@@ -1858,7 +1917,9 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({
           cancelled && requestedCancellationStatus === 'cancelled'
             ? '任务已由本机控制面取消'
             : cancelled ? '用户已暂停，可随时重新执行' : errorMessage,
-          confirmationPaused
+          acceptedObservationActive
+            ? { status: 'manual_submission_observing', code: 'manual_review_required' }
+            : confirmationPaused
             ? {
                 status: 'waiting_generation_confirmation',
                 code: 'generation_confirmation_required',

--- a/src/store/useTaskStore.ts
+++ b/src/store/useTaskStore.ts
@@ -25,6 +25,13 @@ import { useAccountStore } from './useAccountStore';
 import { automationEngine } from '../automation/AutomationEngine';
 import { useProjectStore } from './useProjectStore';
 import { findInteractiveAccountId } from '../utils/interactiveAccount';
+import { completeAcceptedObservation, renewObservationLease, shouldResumeAcceptedObservation } from '../utils/acceptedObservation';
+
+// 账号启动复检可能仍处于 unknown；队列遇到这种软阻断时不能永久停在那里。
+// 只对已满足依赖的 queued 任务做有界退避复检，ready 后由现有调度继续。
+const availabilityRetryAttempts = new Map<string, number>();
+const availabilityRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
 
 // ==================== 类型 ====================
 
@@ -74,14 +81,14 @@ interface TaskState {
     runtime?: Partial<TaskRunSnapshot>;
     errorInfo?: TaskErrorInfo | null;
     result?: string;
-  }) => Promise<void>;
+  }) => Promise<boolean>;
   completeAutomation: (taskId: string, accountId: string, resultUrl: string, outputs?: string[]) => Promise<void>;
   pauseAutomation: (
     taskId: string,
     accountId: string,
     message?: string,
     options?: {
-      status: 'paused' | 'cancelled' | 'waiting_verification' | 'waiting_generation_confirmation';
+      status: 'paused' | 'cancelled' | 'waiting_verification' | 'waiting_generation_confirmation' | 'manual_submission_observing';
       code?: string;
       generationConfirmation?: NonNullable<TaskRunSnapshot['generationConfirmation']>;
     },
@@ -143,7 +150,19 @@ export const useTaskStore = create<TaskState>((set, get) => ({
     try {
       let tasks = await window.electronAPI.tasks.list();
       if (recoverInterrupted) {
-        const activeTasks = tasks.filter((task) => ['executing', 'generating', 'waiting_verification'].includes(task.status));
+        const resumableObservations = tasks.filter(shouldResumeAcceptedObservation);
+        for (const task of resumableObservations) {
+          const now = new Date().toISOString();
+          await window.electronAPI.tasks.updateRuntime(task.id, {
+            status: 'manual_submission_observing',
+            result: '应用界面重新载入，正在从原会话恢复只读产物观察',
+            runtime: { stage: 'manual_submission_observing', message: '正在恢复只读产物观察', stageStartedAt: now, lastHeartbeatAt: now },
+          });
+          if (task.lock?.ownerId) await window.electronAPI.tasks.releaseLock(task.id, task.lock.ownerId);
+        }
+        const activeTasks = tasks.filter((task) =>
+          ['executing', 'generating', 'waiting_verification'].includes(task.status) && !shouldResumeAcceptedObservation(task),
+        );
         for (const task of activeTasks) {
           const now = new Date().toISOString();
           await window.electronAPI.tasks.updateRuntime(task.id, {
@@ -156,7 +175,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
             await window.electronAPI.tasks.releaseLock(task.id, task.lock.ownerId);
           }
         }
-        if (activeTasks.length > 0) tasks = await window.electronAPI.tasks.list();
+        if (activeTasks.length > 0 || resumableObservations.length > 0) tasks = await window.electronAPI.tasks.list();
       }
       set({ tasks, loading: false, executingTasks: {}, accountBusy: {} });
     } catch (err: any) {
@@ -511,6 +530,9 @@ export const useTaskStore = create<TaskState>((set, get) => ({
               stageStartedAt: stage && stage !== task.runtime.stage ? now : task.runtime.stageStartedAt,
               lastHeartbeatAt: now,
               submittedAt: stage === 'submitting' ? (task.runtime.submittedAt || now) : task.runtime.submittedAt,
+              acceptanceObservation: state === 'generating' && task.runtime.acceptanceObservation?.outcome === 'observing'
+                ? renewObservationLease(task.runtime.acceptanceObservation, now)
+                : task.runtime.acceptanceObservation,
             } : task.runtime,
             updatedAt: now,
           }
@@ -549,7 +571,10 @@ export const useTaskStore = create<TaskState>((set, get) => ({
     const result = await window.electronAPI.tasks.updateRuntime(taskId, patch);
     if (result.success && result.task) {
       set({ tasks: get().tasks.map((task) => task.id === taskId ? result.task! : task) });
+      return true;
     }
+    set({ error: result.error || '任务运行状态写入失败' });
+    return false;
   },
 
   completeAutomation: async (taskId: string, accountId: string, resultUrl: string, outputs?: string[]) => {
@@ -567,6 +592,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
       errorInfo: null,
     });
 
+    const completedAt = new Date().toISOString();
     const tasks = get().tasks.map((t) =>
       t.id === taskId
         ? {
@@ -576,8 +602,15 @@ export const useTaskStore = create<TaskState>((set, get) => ({
             outputs: finalOutputs,
             artifacts: mergeArtifacts(t, finalOutputs),
             errorInfo: undefined,
-            runtime: t.runtime ? { ...t.runtime, stage: 'completed' as TaskStage, message: '生成完成' } : t.runtime,
-            updatedAt: new Date().toISOString(),
+            runtime: t.runtime ? {
+              ...t.runtime,
+              stage: 'completed' as TaskStage,
+              message: '生成完成',
+              acceptanceObservation: t.runtime.acceptanceObservation
+                ? completeAcceptedObservation(t.runtime.acceptanceObservation, artifactId(finalOutputs[0]), completedAt)
+                : undefined,
+            } : t.runtime,
+            updatedAt: completedAt,
           }
         : t
     );
@@ -631,7 +664,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
     accountId: string,
     pauseMessage = '用户已暂停',
     options?: {
-      status: 'paused' | 'cancelled' | 'waiting_verification' | 'waiting_generation_confirmation';
+      status: 'paused' | 'cancelled' | 'waiting_verification' | 'waiting_generation_confirmation' | 'manual_submission_observing';
       code?: string;
       generationConfirmation?: NonNullable<TaskRunSnapshot['generationConfirmation']>;
     },
@@ -643,6 +676,8 @@ export const useTaskStore = create<TaskState>((set, get) => ({
       ? 'waiting_verification'
       : targetStatus === 'waiting_generation_confirmation'
         ? 'waiting_generation_confirmation'
+        : targetStatus === 'manual_submission_observing'
+          ? 'manual_submission_observing'
         : 'paused';
     const errorInfo: TaskErrorInfo = {
       code: options?.code || 'cancelled',
@@ -798,7 +833,33 @@ export const useTaskStore = create<TaskState>((set, get) => ({
         }
         if (dependency.state !== 'ready') continue;
         const accountId = task.assignedAccountId!;
+        const accountHasObservation = state.tasks.some((item) =>
+          item.id !== task.id && item.assignedAccountId === accountId &&
+          item.runtime?.acceptanceObservation?.outcome === 'observing',
+        );
+        if (accountHasObservation) continue;
         const account = useAccountStore.getState().accounts.find((item) => item.id === accountId);
+        // 启动后账号会进入“待复检”。若依赖已满足但因为未知可用性被挡住，
+        // 应主动请求一次复检并做有界退避，而不是永久跳过该账号。
+        const availabilityState = account?.health?.availability?.state;
+        if (availabilityState === 'unknown') {
+          const attempts = availabilityRetryAttempts.get(accountId) || 0;
+          if (attempts < 30) {
+            availabilityRetryAttempts.set(accountId, attempts + 1);
+            useAccountStore.getState().requestAvailabilityCheck(accountId);
+            if (!availabilityRetryTimers.has(accountId)) {
+              const delay = Math.min(30_000, 2_000 * 2 ** Math.min(attempts, 4));
+              const timer = setTimeout(() => {
+                availabilityRetryTimers.delete(accountId);
+                get().processQueue();
+              }, delay);
+              availabilityRetryTimers.set(accountId, timer);
+            }
+          }
+          continue;
+        }
+        availabilityRetryAttempts.delete(accountId);
+
         if (getAssignedAccountBlockReason(account, task)) {
           // 用户已明确指派的任务必须保持绑定，不得因冷却/额度/登录状态而静默改派。
           // 自动指派只发生在任务创建或 CSV 导入阶段。

--- a/src/utils/acceptedObservation.ts
+++ b/src/utils/acceptedObservation.ts
@@ -1,0 +1,98 @@
+import type { GenerationMode, Task, TaskRunSnapshot } from '../types';
+import type { SubmissionReadback } from './realSendStateMachine';
+
+export type AcceptanceObservation = NonNullable<TaskRunSnapshot['acceptanceObservation']>;
+
+const DEFAULT_LEASE_MS = 60_000;
+
+export function createAcceptedObservationBinding(input: {
+  accountId: string;
+  runId: string;
+  conversationUrl: string;
+  acceptedAt: string;
+  ownerId: string;
+  mode: GenerationMode;
+  evidence: SubmissionReadback;
+  generationStartedAt?: number;
+  materialAuthorizationConfirmed?: boolean;
+  leaseMs?: number;
+}): AcceptanceObservation {
+  const acceptedMs = new Date(input.acceptedAt).getTime();
+  const leaseMs = Math.max(15_000, input.leaseMs ?? DEFAULT_LEASE_MS);
+  const kind = input.materialAuthorizationConfirmed
+    ? 'material_authorization_confirmed'
+    : input.evidence.generationStarted
+      ? 'generation_started'
+      : 'prompt_published';
+  return {
+    schemaVersion: 1,
+    accountId: input.accountId,
+    runId: input.runId,
+    conversationUrl: input.conversationUrl,
+    acceptedAt: input.acceptedAt,
+    evidence: {
+      kind,
+      messageCount: Math.max(0, input.evidence.messageCount),
+      generationStartedAt: input.generationStartedAt && input.generationStartedAt > 0
+        ? input.generationStartedAt
+        : undefined,
+    },
+    cursor: {
+      messageCount: Math.max(0, input.evidence.messageCount),
+      generationStartedAt: input.generationStartedAt && input.generationStartedAt > 0
+        ? input.generationStartedAt
+        : undefined,
+      pollCount: 0,
+    },
+    expectedArtifact: {
+      kind: input.mode === 'video' ? 'video' : input.mode === 'image' ? 'image' : 'file',
+      runId: input.runId,
+    },
+    lease: {
+      ownerId: input.ownerId,
+      acquiredAt: input.acceptedAt,
+      expiresAt: new Date(acceptedMs + leaseMs).toISOString(),
+      lastHeartbeatAt: input.acceptedAt,
+    },
+    outcome: 'observing',
+  };
+}
+
+export function hasPlatformAcceptance(task: Pick<Task, 'status' | 'runtime'>): boolean {
+  if (task.status === 'done') return true;
+  const binding = task.runtime?.acceptanceObservation;
+  return Boolean(
+    binding &&
+    binding.schemaVersion === 1 &&
+    binding.outcome === 'observing' &&
+    binding.runId === task.runtime?.runId &&
+    binding.accountId &&
+    binding.conversationUrl,
+  );
+}
+
+export function shouldResumeAcceptedObservation(task: Pick<Task, 'status' | 'runtime'>): boolean {
+  return task.status === 'generating' && hasPlatformAcceptance(task);
+}
+
+export function renewObservationLease(binding: AcceptanceObservation, now: string, ttlMs = DEFAULT_LEASE_MS): AcceptanceObservation {
+  return {
+    ...binding,
+    cursor: { ...binding.cursor, pollCount: binding.cursor.pollCount + 1 },
+    lease: {
+      ...binding.lease,
+      lastHeartbeatAt: now,
+      expiresAt: new Date(new Date(now).getTime() + Math.max(15_000, ttlMs)).toISOString(),
+    },
+  };
+}
+
+export function completeAcceptedObservation(binding: AcceptanceObservation, artifactId: string, completedAt: string): AcceptanceObservation {
+  return {
+    ...binding,
+    expectedArtifact: { ...binding.expectedArtifact, artifactId },
+    lease: { ...binding.lease, lastHeartbeatAt: completedAt, expiresAt: completedAt },
+    outcome: 'completed',
+    completedAt,
+  };
+}

--- a/src/utils/dependencyEval.ts
+++ b/src/utils/dependencyEval.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Task } from '../types';
+import { hasPlatformAcceptance } from './acceptedObservation';
 
 export type DependencyEvaluation = {
   state: 'ready' | 'waiting' | 'missing' | 'failed' | 'invalid';
@@ -38,11 +39,13 @@ export function evaluateDependencies(task: Task, tasks: Task[]): DependencyEvalu
   if (hasCycle(task.id)) {
     return { state: 'invalid', message: '任务依赖存在自依赖或循环，当前任务已停止' };
   }
-  if (task.dependencyPolicy !== 'all_finished' && dependencies.some((item) => ['fail', 'cancelled'].includes(item.status))) {
+  if (task.dependencyPolicy === 'all_done' && dependencies.some((item) => ['fail', 'cancelled'].includes(item.status))) {
     return { state: 'failed', message: '前置任务未成功，当前任务已停止' };
   }
   const ready = task.dependencyPolicy === 'all_finished'
     ? dependencies.every((item) => ['done', 'fail', 'cancelled'].includes(item.status))
+    : task.dependencyPolicy === 'all_accepted'
+      ? dependencies.every(hasPlatformAcceptance)
     : dependencies.every((item) => item.status === 'done');
   return ready ? { state: 'ready' } : { state: 'waiting', message: '前置任务尚未满足执行条件' };
 }

--- a/src/utils/realSendStateMachine.ts
+++ b/src/utils/realSendStateMachine.ts
@@ -33,7 +33,7 @@ export function canAttemptSubmission(
 
 export interface SubmissionRecoveryTask {
   status?: string;
-  runtime?: { submittedAt?: string };
+  runtime?: { submittedAt?: string; acceptanceObservation?: { outcome?: string } };
   errorInfo?: { code?: string; message?: string };
   result?: string | null;
 }
@@ -45,6 +45,7 @@ const LEGACY_UNCERTAIN_SUBMISSION = /发送按钮不可用|点击结果不确定
  * 兼容修复前被错误记录为 cancelled 的任务，确保现场中的 C01-A 也被保护。
  */
 export function requiresSubmissionReconciliation(task: SubmissionRecoveryTask | undefined): boolean {
+  if (task?.runtime?.acceptanceObservation?.outcome === 'observing') return true;
   if (task?.status === 'waiting_generation_confirmation' || task?.status === 'manual_submission_observing') return true;
   if (!task?.runtime?.submittedAt) return false;
   if (!['paused', 'waiting_verification', 'waiting_generation_confirmation', 'manual_submission_observing', 'fail', 'cancelled'].includes(task.status || '')) return false;

--- a/tests/unit/acceptedObservation.test.ts
+++ b/tests/unit/acceptedObservation.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { Task } from '../../src/types';
+import {
+  completeAcceptedObservation,
+  createAcceptedObservationBinding,
+  hasPlatformAcceptance,
+  renewObservationLease,
+  shouldResumeAcceptedObservation,
+} from '../../src/utils/acceptedObservation';
+
+const acceptedAt = '2026-09-10T08:00:00.000Z';
+
+function binding() {
+  return createAcceptedObservationBinding({
+    accountId: 'account-1', runId: 'run-1', conversationUrl: 'https://www.doubao.com/chat/one',
+    acceptedAt, ownerId: 'observer-run-1', mode: 'video', generationStartedAt: 123,
+    evidence: { generationStarted: true, inputCleared: true, messageCount: 7, promptPublished: true },
+  });
+}
+
+function task(status: Task['status'], acceptanceObservation = binding()): Task {
+  return {
+    id: 'task-1', prompt: 'secret prompt', assignedAccountId: 'account-1', status, mode: 'video',
+    result: null, outputs: [], createdAt: acceptedAt, updatedAt: acceptedAt,
+    runtime: {
+      runId: 'run-1', attempt: 1, stage: 'generating', message: 'observing', startedAt: acceptedAt,
+      stageStartedAt: acceptedAt, lastHeartbeatAt: acceptedAt, acceptanceObservation,
+      input: { prompt: 'secret prompt', mode: 'video', attachments: ['D:/secret/image.png'] },
+    },
+  };
+}
+
+describe('accepted observation', () => {
+  it('只保留受理观察所需的脱敏字段', () => {
+    const value = binding();
+    expect(value).toMatchObject({
+      schemaVersion: 1, accountId: 'account-1', runId: 'run-1', outcome: 'observing',
+      evidence: { kind: 'generation_started', messageCount: 7, generationStartedAt: 123 },
+      cursor: { messageCount: 7, generationStartedAt: 123, pollCount: 0 },
+      expectedArtifact: { kind: 'video', runId: 'run-1' },
+    });
+    expect(JSON.stringify(value)).not.toContain('secret prompt');
+    expect(JSON.stringify(value)).not.toContain('secret/image');
+  });
+
+  it.each([
+    ['material authorization', true, 'material_authorization_confirmed'],
+    ['prompt published', false, 'prompt_published'],
+  ] as const)('%s 生成正确证据类型', (_label, materialAuthorizationConfirmed, kind) => {
+    const value = createAcceptedObservationBinding({
+      accountId: 'a', runId: 'r', conversationUrl: 'https://www.doubao.com/chat/r', acceptedAt,
+      ownerId: 'o', mode: 'chat', materialAuthorizationConfirmed,
+      evidence: { generationStarted: false, inputCleared: true, messageCount: 1, promptPublished: true },
+    });
+    expect(value.evidence.kind).toBe(kind);
+    expect(value.expectedArtifact.kind).toBe('file');
+  });
+
+  it('只有同一 run 的 observing 绑定或历史 done 满足平台受理', () => {
+    expect(hasPlatformAcceptance(task('generating'))).toBe(true);
+    expect(hasPlatformAcceptance(task('done', undefined as never))).toBe(true);
+    const mismatch = binding(); mismatch.runId = 'old-run';
+    expect(hasPlatformAcceptance(task('generating', mismatch))).toBe(false);
+    const completed = binding(); completed.outcome = 'completed';
+    expect(hasPlatformAcceptance(task('generating', completed))).toBe(false);
+  });
+
+  it('仅 generating + 有效受理绑定需要在重启后恢复观察', () => {
+    expect(shouldResumeAcceptedObservation(task('generating'))).toBe(true);
+    expect(shouldResumeAcceptedObservation(task('manual_submission_observing'))).toBe(false);
+  });
+
+  it('续租递增游标且完成时绑定稳定 artifact ID', () => {
+    const renewed = renewObservationLease(binding(), '2026-09-10T08:00:15.000Z', 30_000);
+    expect(renewed.cursor.pollCount).toBe(1);
+    expect(renewed.lease.expiresAt).toBe('2026-09-10T08:00:45.000Z');
+    const completed = completeAcceptedObservation(renewed, 'artifact-1', '2026-09-10T08:01:00.000Z');
+    expect(completed).toMatchObject({ outcome: 'completed', completedAt: '2026-09-10T08:01:00.000Z', expectedArtifact: { artifactId: 'artifact-1' } });
+  });
+});
+
+describe('accepted observation pipeline 接线契约', () => {
+  const panel = readFileSync(resolve(__dirname, '../../src/components/BrowserPanel.tsx'), 'utf8');
+  const store = readFileSync(resolve(__dirname, '../../src/store/useTaskStore.ts'), 'utf8');
+
+  it('明确受理后先原子持久化并回读观察绑定，再触发 generating 队列', () => {
+    const start = panel.indexOf('const acceptedAt = new Date().toISOString()');
+    const end = panel.indexOf('let generating = true', start);
+    const body = panel.slice(start, end);
+    expect(start).toBeGreaterThan(0);
+    expect(body.indexOf('createAcceptedObservationBinding')).toBeLessThan(body.indexOf('await updateTaskRuntime'));
+    expect(body.indexOf('await updateTaskRuntime')).toBeLessThan(body.indexOf('persistedObservation'));
+    expect(body.indexOf('persistedObservation')).toBeLessThan(body.indexOf("setAccountAutomationState(accountId, 'generating'"));
+    expect(body).toContain('throw new SubmissionSafetyPauseError');
+  });
+
+  it('观察恢复只派发既有只读 reconcile，不调用第二套发送链路', () => {
+    const start = panel.indexOf('应用重启或页面重新挂载后，只沿已持久化的原会话恢复观察');
+    const end = panel.indexOf('// ---- 自动化执行 ----', start);
+    const body = panel.slice(start, end);
+    expect(body).toContain("new CustomEvent('reconcile-task-submission'");
+    expect(body).not.toContain('submitPromptWithNativeClick');
+    expect(body).not.toContain('injectPrompt');
+  });
+
+  it('同账号 observing 时主动跳过，Renderer reload 仅恢复观察', () => {
+    expect(store).toContain('const accountHasObservation = state.tasks.some');
+    expect(store).toContain('if (accountHasObservation) continue;');
+    expect(store).toContain('const resumableObservations = tasks.filter(shouldResumeAcceptedObservation)');
+    expect(store).toContain('!shouldResumeAcceptedObservation(task)');
+    expect(panel).toMatch(/acceptedObservationActive\s*\? \{ status: 'manual_submission_observing'/);
+  });
+});

--- a/tests/unit/contracts.test.ts
+++ b/tests/unit/contracts.test.ts
@@ -108,9 +108,9 @@ describe('@doubao-studio/contracts', () => {
     expect(ratio).toBe('1:1');
   });
 
-  it('DependencyPolicy 包含 all_done / all_finished', () => {
-    const policy: DependencyPolicy = 'all_done';
-    expect(policy).toBe('all_done');
+  it('DependencyPolicy 包含 all_done / all_accepted / all_finished', () => {
+    const policies: DependencyPolicy[] = ['all_done', 'all_accepted', 'all_finished'];
+    expect(policies).toContain('all_accepted');
   });
 
   it('所有类型均为字符串字面量联合（运行时仍为 string）', () => {

--- a/tests/unit/dependencyEval.test.ts
+++ b/tests/unit/dependencyEval.test.ts
@@ -95,6 +95,48 @@ describe('evaluateDependencies', () => {
     expect(evaluateDependencies(task, [dep1, dep2, task]).state).toBe('ready');
   });
 
+  // ---- all_accepted 策略 ----
+
+  it.each([
+    ['done 历史任务', makeTask({ id: 'd1', status: 'done' }), 'ready'],
+    ['明确受理并观察中', makeTask({ id: 'd1', status: 'generating', runtime: {
+      runId: 'run-1', attempt: 1, stage: 'generating', message: '观察中', startedAt: '2025-01-01T00:00:00.000Z',
+      stageStartedAt: '2025-01-01T00:00:00.000Z', lastHeartbeatAt: '2025-01-01T00:00:00.000Z',
+      acceptanceObservation: {
+        schemaVersion: 1, accountId: 'a1', runId: 'run-1', conversationUrl: 'https://www.doubao.com/chat/one',
+        acceptedAt: '2025-01-01T00:00:00.000Z', evidence: { kind: 'generation_started' },
+        cursor: { messageCount: 1, pollCount: 0 }, expectedArtifact: { kind: 'video', runId: 'run-1' },
+        lease: { ownerId: 'o1', acquiredAt: '2025-01-01T00:00:00.000Z', expiresAt: '2025-01-01T00:01:00.000Z', lastHeartbeatAt: '2025-01-01T00:00:00.000Z' },
+        outcome: 'observing',
+      }, input: { prompt: 'x', mode: 'video', attachments: [] },
+    } }), 'ready'],
+    ['generating 但无绑定', makeTask({ id: 'd1', status: 'generating' }), 'waiting'],
+    ['仅有 submittedAt', makeTask({ id: 'd1', status: 'paused', runtime: {
+      runId: 'r', attempt: 1, stage: 'paused', message: 'uncertain', startedAt: '2025-01-01T00:00:00.000Z',
+      stageStartedAt: '2025-01-01T00:00:00.000Z', lastHeartbeatAt: '2025-01-01T00:00:00.000Z', submittedAt: '2025-01-01T00:00:00.000Z',
+      input: { prompt: 'x', mode: 'video', attachments: [] },
+    }, errorInfo: { code: 'submission_uncertain', message: 'unknown', recoverable: true, detectedAt: '2025-01-01T00:00:00.000Z' } }), 'waiting'],
+  ])('all_accepted: %s → %s', (_label, dependency, expected) => {
+    const task = makeTask({ id: 't1', dependsOnTaskIds: ['d1'], dependencyPolicy: 'all_accepted' });
+    expect(evaluateDependencies(task, [dependency, task]).state).toBe(expected);
+  });
+
+  it('all_accepted: 前置受理后即使后续进入 fail，仍视为已受理且不重复提交', () => {
+    const dependency = makeTask({ id: 'd1', status: 'fail', runtime: {
+      runId: 'run-accepted', attempt: 1, stage: 'failed', message: '产物观察失败', startedAt: '2025-01-01T00:00:00.000Z',
+      stageStartedAt: '2025-01-01T00:00:00.000Z', lastHeartbeatAt: '2025-01-01T00:00:00.000Z',
+      acceptanceObservation: {
+        schemaVersion: 1, accountId: 'a1', runId: 'run-accepted', conversationUrl: 'https://www.doubao.com/chat/accepted',
+        acceptedAt: '2025-01-01T00:00:00.000Z', evidence: { kind: 'prompt_published' }, cursor: { messageCount: 1, pollCount: 0 },
+        expectedArtifact: { kind: 'video', runId: 'run-accepted' }, lease: {
+          ownerId: 'o1', acquiredAt: '2025-01-01T00:00:00.000Z', expiresAt: '2025-01-01T00:01:00.000Z', lastHeartbeatAt: '2025-01-01T00:00:00.000Z',
+        }, outcome: 'observing',
+      }, input: { prompt: 'x', mode: 'video', attachments: [] },
+    } });
+    const task = makeTask({ id: 't1', dependsOnTaskIds: ['d1'], dependencyPolicy: 'all_accepted' });
+    expect(evaluateDependencies(task, [dependency, task]).state).toBe('ready');
+  });
+
   // ---- 缺失依赖 ----
 
   it('依赖不存在的任务 → missing', () => {

--- a/tests/unit/persistenceNormalization.test.ts
+++ b/tests/unit/persistenceNormalization.test.ts
@@ -699,6 +699,30 @@ describe('normalizeTasks', () => {
     expect(JSON.stringify(normalized.runtime?.executionDiagnostics)).not.toContain('secret');
   });
 
+  it('受理观察绑定与 all_accepted 跨重启白名单保留，未知嵌套字段被删除', () => {
+    const task = makeValidTask();
+    task.dependencyPolicy = 'all_accepted';
+    task.runtime = {
+      runId: 'run-accepted', attempt: 1, stage: 'generating', message: '观察中',
+      startedAt: NOW, stageStartedAt: NOW, lastHeartbeatAt: NOW,
+      input: { prompt: 'secret prompt', mode: 'video', attachments: ['D:/secret.png'] },
+      acceptanceObservation: {
+        schemaVersion: 1, accountId: 'account-1', runId: 'run-accepted', conversationUrl: 'https://www.doubao.com/chat/accepted',
+        acceptedAt: NOW, evidence: { kind: 'generation_started', messageCount: 4, generationStartedAt: 100 },
+        cursor: { messageCount: 4, generationStartedAt: 100, pollCount: 2 }, expectedArtifact: { kind: 'video', runId: 'run-accepted' },
+        lease: { ownerId: 'observer-1', acquiredAt: NOW, expiresAt: '2026-08-28T00:01:00.000Z', lastHeartbeatAt: NOW }, outcome: 'observing',
+      },
+    };
+    (task.runtime.acceptanceObservation as unknown as Record<string, unknown>).cookie = 'must-not-survive';
+    const normalized = normalizeTasks([task], DEFAULT_PROJECT_ID, NOW).data[0];
+    expect(normalized.dependencyPolicy).toBe('all_accepted');
+    expect(normalized.runtime?.acceptanceObservation).toMatchObject({
+      schemaVersion: 1, accountId: 'account-1', runId: 'run-accepted', outcome: 'observing',
+      cursor: { messageCount: 4, generationStartedAt: 100, pollCount: 2 },
+    });
+    expect(JSON.stringify(normalized.runtime?.acceptanceObservation)).not.toContain('must-not-survive');
+  });
+
   // ---- 测试 7: 重复任务 ID 去重 ----
   it('重复任务 ID 只保留第一个且记录警告', () => {
     const t1 = makeValidTask(); t1.id = 'dup-task'; t1.prompt = '任务1';

--- a/tests/unit/real-send-recovery.test.ts
+++ b/tests/unit/real-send-recovery.test.ts
@@ -213,6 +213,7 @@ describe('P0-2 已提交任务只读核对门禁', () => {
     const cases = [
       { name: '新错误码', task: { status: 'paused', runtime: { submittedAt }, errorInfo: { code: 'submission_uncertain' } }, expected: true },
       { name: '旧 cancelled 文案', task: { status: 'paused', runtime: { submittedAt }, errorInfo: { code: 'cancelled', message: '发送按钮不可用或点击结果不确定' } }, expected: true },
+      { name: '已受理观察即使状态异常也禁止重发', task: { status: 'fail', runtime: { acceptanceObservation: { outcome: 'observing' } } }, expected: true },
       { name: '无提交记录的普通暂停', task: { status: 'paused', errorInfo: { code: 'cancelled', message: '用户暂停' } }, expected: false },
       { name: '已完成任务', task: { status: 'done', runtime: { submittedAt }, errorInfo: { code: 'submission_uncertain' } }, expected: false },
     ];

--- a/tests/unit/taskService.test.ts
+++ b/tests/unit/taskService.test.ts
@@ -38,6 +38,23 @@ describe('TaskService 核心用例', () => {
     expect(stored()[0].outputs).toEqual(['u']); expect(stored()[0].artifacts).toHaveLength(1); expect(stored()[0].errorInfo).toBeUndefined();
   });
 
+  it('完成任务时在同一次写入中绑定 artifact 并收口受理观察', () => {
+    const item = withRuntime(base('accepted', 'generating'), 'generating');
+    item.runtime!.acceptanceObservation = {
+      schemaVersion: 1, accountId: 'a1', runId: 'r', conversationUrl: 'https://www.doubao.com/chat/r',
+      acceptedAt: 'old', evidence: { kind: 'generation_started' }, cursor: { messageCount: 1, pollCount: 0 },
+      expectedArtifact: { kind: 'video', runId: 'r' },
+      lease: { ownerId: 'o', acquiredAt: 'old', expiresAt: 'old', lastHeartbeatAt: 'old' }, outcome: 'observing',
+    };
+    const { service, stored } = fixture([item]);
+    expect(service.updateStatus({ taskId: 'accepted', status: 'done', outputs: ['https://video.example/a.mp4'] }).success).toBe(true);
+    const task = stored()[0];
+    expect(task.runtime?.acceptanceObservation).toMatchObject({
+      outcome: 'completed', completedAt: 'now', expectedArtifact: { artifactId: task.artifacts?.[0].id },
+      lease: { lastHeartbeatAt: 'now', expiresAt: 'now' },
+    });
+  });
+
   it('执行中或存在下游依赖时禁止删除', () => {
     expect(fixture([base('t1', 'executing')]).service.delete('t1').success).toBe(false);
     const child = base('child'); child.dependsOnTaskIds = ['t1'];
@@ -790,6 +807,25 @@ describe('TaskService recoverInterruptedTasks', () => {
     });
   });
 
+  it('已有受理绑定的 generating 跨重启转为只读观察且不结束 runHistory', () => {
+    const item = activeTask('accepted-observe', 'generating');
+    item.runtime!.acceptanceObservation = {
+      schemaVersion: 1, accountId: 'a1', runId: 'r', conversationUrl: 'https://www.doubao.com/chat/r',
+      acceptedAt: RECOVERY_STARTED_AT, evidence: { kind: 'generation_started' }, cursor: { messageCount: 2, pollCount: 0 },
+      expectedArtifact: { kind: 'video', runId: 'r' }, lease: {
+        ownerId: 'observer-r', acquiredAt: RECOVERY_STARTED_AT, expiresAt: RECOVERY_NOW, lastHeartbeatAt: RECOVERY_STARTED_AT,
+      }, outcome: 'observing',
+    };
+    const { service, stored } = recoveryFixture([item]);
+    expect(service.recoverInterruptedTasks()).toEqual({ success: true, data: { recoveredTasks: 1, clearedLocks: 1 } });
+    expect(stored()[0]).toMatchObject({
+      status: 'manual_submission_observing', lock: undefined,
+      runtime: { stage: 'manual_submission_observing', acceptanceObservation: { outcome: 'observing', lease: { expiresAt: RECOVERY_NOW } } },
+    });
+    expect(stored()[0].runHistory?.[0].finishedAt).toBeUndefined();
+    expect(service.retry('accepted-observe').success).toBe(false);
+  });
+
   it('非活动任务只清除遗留 lock，无 lock 时完全不变', () => {
     const withLock = base('t1', 'done');
     withLock.lock = { ownerId: 'old', acquiredAt: 'old', expiresAt: 'old' };
@@ -1239,6 +1275,7 @@ describe('TaskService importCsv', () => {
 
   it.each([
     ['all_finished', 'all_finished'],
+    ['all_accepted', 'all_accepted'],
     ['all_done', 'all_done'],
     ['', 'all_done'],
   ])('dependencyPolicy「%s」映射为 %s', (input, expected) => {


### PR DESCRIPTION
## Summary
- add fail-closed all_accepted dependency semantics
- atomically persist redacted platform-acceptance observation bindings before queue release
- recover observation from the original conversation across reloads and restarts
- preserve same-account serialization while allowing different-account successors
- add startup queue evaluation and bounded availability rechecks from the R1 real-acceptance finding

## Validation
- integrated on top of PR #39 / main 081ba7f
- validate: 49 files / 1030 tests pass
- ESLint: 0 errors / 147 warnings
- renderer/main build and Windows pack pass
- real acceptance: one 5s task submitted once and bound to artifact-d46a8e96
- multi-account all_accepted released the different-account successor; same-account successor stayed queued

Dola remains unverified. No credentials, sessions, task ledgers, artifacts, or acceptance copies are included.